### PR TITLE
Remove hardcoded SDK and DEVROOT.

### DIFF
--- a/tools/build-sdl.sh
+++ b/tools/build-sdl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname $0)/environment.sh
 pushd $KIVYIOSROOT/src/SDL/Xcode-iPhoneOS/SDL
-xcodebuild -project SDLiPhoneOS.xcodeproj -target libSDL -configuration Release -sdk iphoneos5.0
+xcodebuild -project SDLiPhoneOS.xcodeproj -target libSDL -configuration Release -sdk iphoneos$SDKVER
 popd
 
 cp src/SDL/Xcode-iPhoneOS/SDL/build/Release-iPhoneOS/libSDL.a $BUILDROOT/lib

--- a/tools/create-xcode-project.sh
+++ b/tools/create-xcode-project.sh
@@ -27,6 +27,7 @@ try cp -a $TEMPLATESDIR/template.xcodeproj $APPDIR/$APPID.xcodeproj
 echo "-> Customize templates"
 try find $APPDIR -type f -exec sed -i '' "s/##APPID##/$APPID/g" {} \;
 try find $APPDIR -type f -exec sed -i '' "s/##APPNAME##/$APPNAME/g" {} \;
+try find $APPDIR -type f -exec sed -i '' "s/##SDKVER##/$SDKVER/g" {} \;
 
 echo "-> Done !"
 

--- a/tools/environment.sh
+++ b/tools/environment.sh
@@ -7,8 +7,8 @@ try () {
 }
 
 # iOS SDK Environmnent
-export SDKVER=5.0
-export DEVROOT=/Developer/Platforms/iPhoneOS.platform/Developer
+export SDKVER=`xcodebuild -showsdks | fgrep "iphoneos" | tail -n 1 | awk '{print $2}'`
+export DEVROOT=`xcode-select -print-path`/Platforms/iPhoneOS.platform/Developer
 export SDKROOT=$DEVROOT/SDKs/iPhoneOS$SDKVER.sdk
 
 # version of packages

--- a/tools/templates/template.xcodeproj/project.pbxproj
+++ b/tools/templates/template.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 					"\"$(PROJECT_DIR)/../build/python/include\"",
 				);
 				INFOPLIST_FILE = "##APPID##-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = ##SDKVER##;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(PROJECT_DIR)/../build/lib\"",
@@ -286,7 +286,7 @@
 					"\"$(PROJECT_DIR)/../build/python/include\"",
 				);
 				INFOPLIST_FILE = "##APPID##-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = ##SDKVER##;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(PROJECT_DIR)/../build/lib\"",
@@ -314,7 +314,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = ##SDKVER##;
 				ONLY_ACTIVE_ARCH = YES;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -339,7 +339,7 @@
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = ##SDKVER##;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
These changes determine the SDK version and DEVROOT using tools distributed with Xcode. It takes into account the differences between Xcode versions and chooses the highest iphoneos SDK installed. I have tested this on OSX Lion and Xcode 4, but it should work universally.
