### PR TITLE
MacPorts enabling

### DIFF
--- a/tools/build-sdlmixer.sh
+++ b/tools/build-sdlmixer.sh
@@ -45,7 +45,7 @@ if [ ! -f libtremor/tremor/.libs/libvorbisidec.a ]; then
 	OGG_CFLAGS="-I../../libogg/include" \
 	OGG_LDFLAGS="-L../../libogg/src/.libs" \
 	PKG_CONFIG_LIBDIR="../../libogg" \
-	ACLOCAL_FLAGS="-I /usr/local/share/aclocal" ./autogen.sh \
+	ACLOCAL_FLAGS="-I /usr/local/share/aclocal -I /opt/local/share/aclocal" ./autogen.sh \
 		--disable-shared \
 		--host=arm-apple-darwin \
 		--enable-static=yes \


### PR DESCRIPTION
Added an Include library to ACLOCAL_FLAGS to search the autoconf
directory when MacPorts was used to install dependencies.
MacPorts installs by default into /opt/local.
