### PR TITLE
Enable building on MacPorts based installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@ Kivy for IOS
     pip install cython
 
 #. Build the whole toolchain with `tools/build_all.sh`
+
+   Make sure the output ends with '== Build ended'
+
 #. Create an Xcode project for your application with `tools/create-xcode-project.sh test /path/to/app`
 #. Open your newly created Xcode project
 #. Ensure code signing is setup correctly

--- a/tools/build-sdlmixer.sh
+++ b/tools/build-sdlmixer.sh
@@ -45,7 +45,7 @@ if [ ! -f libtremor/tremor/.libs/libvorbisidec.a ]; then
 	OGG_CFLAGS="-I../../libogg/include" \
 	OGG_LDFLAGS="-L../../libogg/src/.libs" \
 	PKG_CONFIG_LIBDIR="../../libogg" \
-	ACLOCAL_FLAGS="-I /usr/local/share/aclocal -I /opt/local/share/aclocal" ./autogen.sh \
+	ACLOCAL_FLAGS="-I `aclocal --print-ac-dir`" ./autogen.sh \
 		--disable-shared \
 		--host=arm-apple-darwin \
 		--enable-static=yes \


### PR DESCRIPTION
In contrast to my previous pull request, this one has been tested from afresh on my MacPorts based installation. Please test on a Homebrew based installation as well.

Homebrew has the macros in /usr/local/share/aclocal;
MacPorts has the macros in /opt/local/share/aclocal;
I don't understand why the -I argument is needed with either of
these directories, since
aclocal --print-ac-dir returns this directory.
The AC_DIR is searched by default.
An -I argument directory is searched before AC_DIR
See:
http://www.slac.stanford.edu/comp/unix/package/rtems/doc/
html/automake/automake.info.Macro_search_path.html
