### PR TITLE
Adding python to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,12 @@ Kivy for IOS
     brew link libtool
     brew link mercurial
 
-#. Install Cython
-##. Install Python, if not already done!::
+#. Install Python, if not already done (Needed for pip)::
+    
     brew install python
 
-##. Use pip to install Cython::
+#. Install Cython using pip::
+
     pip install cython
 
 #. Build the whole toolchain with `tools/build_all.sh`


### PR DESCRIPTION
Added information that python is needed for pip.

I'm experimenting now with kivy-ios using my MacOSX VM and I found out that python is missing for pip.
Had no python installed via brew or something else, so I decided to add it.

Think it could be useful for other new developers!
