### PR TITLE
fix: prevent 'illegal byte code sequence' when parsing png files

### DIFF
--- a/tools/create-xcode-project.sh
+++ b/tools/create-xcode-project.sh
@@ -32,10 +32,10 @@ try cp $TEMPLATESDIR/template-Info.plist $APPDIR/$APPID-Info.plist
 try cp -a $TEMPLATESDIR/template.xcodeproj $APPDIR/$APPID.xcodeproj
 
 echo "-> Customize templates"
-try find $APPDIR -type f -exec sed -i '' "s/##APPID##/$APPID/g" {} \;
-try find $APPDIR -type f -exec sed -i '' "s/##APPNAME##/$APPNAME/g" {} \;
-try find $APPDIR -type f -exec sed -i '' "s/##SDKVER##/$SDKVER/g" {} \;
-try find $APPDIR -type f -exec sed -i '' "s^##SRCDIR##^$SRCDIR^g" {} \;
+try find $APPDIR -type f -not -iname *.png -exec sed -i '' "s/##APPID##/$APPID/g" {} \;
+try find $APPDIR -type f -not -iname *.png -exec sed -i '' "s/##APPNAME##/$APPNAME/g" {} \;
+try find $APPDIR -type f -not -iname *.png -exec sed -i '' "s/##SDKVER##/$SDKVER/g" {} \;
+try find $APPDIR -type f -not -iname *.png -exec sed -i '' "s^##SRCDIR##^$SRCDIR^g" {} \;
 
 echo "-> Done !"
 


### PR DESCRIPTION
When running "create-xcode-project", I was getting errors:

-> Customize temple
sed RE error: illegal byte sequence
sed RE error: illegal byte sequence
sed RE error: illegal byte sequence
sed RE error: illegal byte sequence
-> Done

Seems to be chocking on the PNG's so added a skip of these files
