### PR TITLE
Fixes the bug that MFMailComposeViewController not presented properly.

### DIFF
--- a/src/ios/ios_mail.m
+++ b/src/ios/ios_mail.m
@@ -13,15 +13,15 @@
 /* guess the view controller from our SDL window.
  */
 UIViewController *get_viewcontroller(void) {
-	NSArray *windows = [[UIApplication sharedApplication] windows];
-	if ( windows == NULL ) {
-		printf("ios_wrapper: unable to get windows from shared application\n");
+	UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+	if ( window == NULL ) {
+		printf("ios_wrapper: unable to get key window from shared application\n");
 		return NULL;
 	}
-	UIWindow *uiWindow = [windows objectAtIndex:0];
-	UIView* view = [uiWindow.subviews objectAtIndex:0]; 
-	id nextResponder = [view nextResponder]; 
-	if( [nextResponder isKindOfClass:[UIViewController class]] ) 
+  // return window.rootViewController;
+	UIView* view = [window.subviews objectAtIndex:0];
+	id nextResponder = [view nextResponder];
+	if( [nextResponder isKindOfClass:[UIViewController class]] )
 		return (UIViewController *)nextResponder;
 	return NULL;
 }
@@ -42,7 +42,6 @@ UIViewController *get_viewcontroller(void) {
 @synthesize callback;
 
 - (void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
-	UIViewController* viewController = get_viewcontroller();
 	static char *statuses[] = {"unknown", "cancelled",  "saved", "sent", "failed"};
 
 	if ( callback != NULL ) {
@@ -58,8 +57,8 @@ UIViewController *get_viewcontroller(void) {
 		callback(status, userdata);
 	}
 
-	[viewController becomeFirstResponder];
-	[viewController dismissModalViewControllerAnimated:NO];
+  UIViewController* viewController = [controller presentingViewController];
+	[viewController dismissModalViewControllerAnimated:YES];
 }
 
 @end
@@ -103,7 +102,7 @@ int ios_send_email(char *subject, char *text, char *mimetype, char *filename,
 	}
 
 	controller.modalPresentationStyle = UIModalPresentationPageSheet;
-	[viewController presentModalViewController:controller animated:NO];
+	[viewController presentModalViewController:controller animated:YES];
 	[controller release];
 
 	return 1;


### PR DESCRIPTION
The get_viewcontroller() function assumed the SDL window is always the first window in the shared application. However, it is not there. This commit assumes the SDL window is the keyWindow of the shared application.

In the mailComposeController:didFinishWithResult:error: method. The code originally uses the same get_viewcontroller() function to dismiss the modal view. However, uses [controller presentingViewController] is more promising to make sure the view controller that presents the MFMailComposeViewController.

There are also errors showed in the log if animation is disabled. So I changed to use animation on both presenting and dismissing. And the errors in log gone.

Signed-off-by: Olli Wang olliwang@ollix.com
