### PR TITLE
Update print and open file statements for Python3 compatibility.

### DIFF
--- a/tools/biglink
+++ b/tools/biglink
@@ -29,7 +29,7 @@ for fn in sofiles:
     libsfn = fn + ".libs"
 
     args.append(afn)
-    args.extend(file(libsfn).read().split(" "))
+    args.extend(open(libsfn).read().split(" "))
 
 unique_args = [ ]
 
@@ -40,5 +40,5 @@ while args:
 
 
 unique_args = ' '.join([ x for x in unique_args if x.endswith('.so.o') ])
-print 'Biglink create %s library' % sys.argv[1]
+print('Biglink create %s library' % sys.argv[1])
 subprocess.Popen(("ar -q %s " % sys.argv[1]) + unique_args, shell=True).communicate()

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -18,7 +18,7 @@ def resolve_cython():
                 return
 
 def do(fn):
-    print 'cythonize:', fn
+    print('cythonize:', fn)
     parts = fn.split('/')
     assert(parts[-1].endswith('.pyx'))
     if parts[0] == '.':
@@ -30,7 +30,7 @@ def do(fn):
     subprocess.Popen([cython, fn], env=os.environ).communicate()
 
     if not package:
-        print 'no need to rewrite', fn
+        print('no need to rewrite', fn)
     else:
         # get the .c, and change the initXXX
         fn_c = fn[:-3] + 'c'
@@ -44,19 +44,19 @@ def do(fn):
         pat3 = 'Pyx_NAMESTR("{}")'.format(modname)
         sub3 = 'Pyx_NAMESTR("{}_{}")'.format(package, modname)
 
-        print '1: {} -> {}'.format(pat1, sub1)
-        print '2: {} -> {}'.format(pat2, sub2)
-        print '3: {} -> {}'.format(pat3, sub3)
+        print('1: {} -> {}'.format(pat1, sub1))
+        print('2: {} -> {}'.format(pat2, sub2))
+        print('3: {} -> {}'.format(pat3, sub3))
         data = data.replace(pat1, sub1)
         data = data.replace(pat2, sub2)
         data = data.replace(pat3, sub3)
 
-        print 'rewrite', fn_c
+        print('rewrite', fn_c)
         with open(fn_c, 'w') as fd:
             fd.write(data)
 
 if __name__ == '__main__':
-    print '-- cythonize', sys.argv
+    print('-- cythonize', sys.argv)
     resolve_cython()
     for fn in sys.argv[1:]:
         do(fn)

--- a/tools/liblink
+++ b/tools/liblink
@@ -51,10 +51,10 @@ while i < len(sys.argv):
 
     if opt.startswith('-arch'):
         continue
-    
+
     if opt.startswith("-"):
-        print sys.argv
-        print "Unknown option: ", opt
+        print(sys.argv)
+        print("Unknown option: ", opt)
         sys.exit(1)
 
     if not opt.endswith('.o'):
@@ -63,14 +63,14 @@ while i < len(sys.argv):
     objects.append(opt)
 
 
-f = file(output, "w")
+f = open(output, "w")
 f.close()
 
-f = file(output + ".libs", "w")
+f = open(output + ".libs", "w")
 f.write(" ".join(libs))
 f.close()
 
-print 'Liblink redirect linking with', objects
+print('Liblink redirect linking with', objects)
 subprocess.call([
     environ.get('ARM_LD'), '-r',
     '-o', output + '.o', '-arch', 'armv7'] + objects)


### PR DESCRIPTION
Replaces print statement as print() and replaces file() with open() to resolve error occurred when running the `tools/build-ios.sh` script under Python 3 environment.

Signed-off-by: Olli Wang olliwang@ollix.com
