### PR TITLE
Fixes #100

### DIFF
--- a/tools/build-libffi.sh
+++ b/tools/build-libffi.sh
@@ -21,6 +21,9 @@ fi
 pushd $TMPROOT/libffi-$FFI_VERSION
 try patch -p1 < $KIVYIOSROOT/src/ffi_files/ffi-$FFI_VERSION-sysv.S.patch
 
+# libffi needs to use "-miphoneos-version-min=6.0" for xcode 6+ to compile it correctly
+sed -i.bak s/-miphoneos-version-min=4.0/-miphoneos-version-min=6.0/g generate-ios-source-and-headers.py
+
 try xcodebuild -project libffi.xcodeproj -target "libffi iOS" -configuration Release -sdk iphoneos$SDKVER OTHER_CFLAGS="-no-integrated-as"
 
 try cp build/Release-iphoneos/libffi.a $BUILDROOT/lib/libffi.a


### PR DESCRIPTION
libffi would not build with xcode 6 because libffi version 3.0.13 uses a iphoneos min version of 4.0 for compiling for the simluator, but it works if you change the iphoneos min version to 6.0. libffi version 3.1(latest) has a iphoneos min version of 5.1.1 and has the same problem. Solution would be to disable compiling for the simulator, or changing the version. I opted for the later, as I am working on ios simulator support. 
