### PR TITLE
move LDFLAG -undefined dynamic_lookup to python recipe

### DIFF
--- a/recipes/ffmpeg/__init__.py
+++ b/recipes/ffmpeg/__init__.py
@@ -39,18 +39,6 @@ class FFMpegRecipe(Recipe):
                 "--extra-ldflags={}".format(build_env["LDFLAGS"]),
                 *options,
                 _env=build_env)
-        shprint(sh.sed,
-                "-i.bak",
-                "s/HAVE_CLOSESOCKET=yes//g",
-                "config.mak")
-        shprint(sh.sed,
-                "-i.bak",
-                "s/#define HAVE_CLOSESOCKET 1//g",
-                "config.h")
-        shprint(sh.sed,
-                "-i.bak",
-                "s/%define HAVE_CLOSESOCKET 1//g",
-                "config.asm")
         shprint(sh.make, "clean", _env=build_env)
         shprint(sh.make, "-j3", _env=build_env)
         shprint(sh.make, "install")

--- a/recipes/python/__init__.py
+++ b/recipes/python/__init__.py
@@ -40,7 +40,7 @@ class PythonRecipe(Recipe):
                 "CC={}".format(build_env["CC"]),
                 "LD={}".format(build_env["LD"]),
                 "CFLAGS={}".format(build_env["CFLAGS"]),
-                "LDFLAGS={}".format(build_env["LDFLAGS"]),
+                "LDFLAGS={} -undefined dynamic_lookup".format(build_env["LDFLAGS"]),
                 "--without-pymalloc",
                 "--disable-toolbox-glue",
                 "--host={}-apple-darwin".format(arch),

--- a/toolchain.py
+++ b/toolchain.py
@@ -164,7 +164,6 @@ class Arch(object):
             "--sysroot", self.sysroot,
             "-L{}/{}".format(self.ctx.dist_dir, "lib"),
             "-lsqlite3",
-            "-undefined", "dynamic_lookup",
             self.version_min
         ])
         return env


### PR DESCRIPTION
This fixes the FFmpeg arm64 build which failed with:

```
libavutil/random_seed.c:82:23: error: implicit declaration of function 
    'gethrtime' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```

I tracked this down to the LDFLAG -undefined dynamic_lookup. I must confess i do not yet fully understand why this is causing the error. 

https://github.com/kivy/kivy-ios/blob/3bf4339d12b941391c142485a5d43778c1358cd8/recipes/ffmpeg/__init__.py#L42:L53 seems to be a hotfix for the same problem. 
