### PR TITLE
mpath of a six module can be an empty list

### DIFF
--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -119,7 +119,7 @@ void load_custom_builtin_importer() {
         "    def find_module(self, fullname, mpath=None):\n" \
         "        if '.' not in fullname:\n" \
         "            return\n" \
-        "        if mpath is None:\n" \
+        "        if not mpath:\n" \
         "            return\n" \
         "        part = fullname.rsplit('.')[-1]\n" \
         "        fn = join(mpath[0], '{}.so'.format(part))\n" \


### PR DESCRIPTION
Without this patch you will get an error like this:

``` python
myapp.app/lib/python2.7/site-packages/zeroconf.py", line 37, in <module>
     from six.moves import xrange
   File "<string>", line 19, in find_module
 IndexError: list index out of range
```
