### PR TITLE
Clarifies docs to clarify building recipes

### DIFF
--- a/toolchain.py
+++ b/toolchain.py
@@ -1060,7 +1060,7 @@ if __name__ == "__main__":
                     usage="""toolchain <command> [<args>]
                     
 Available commands:
-    build         Build a specific recipe
+    build         Build an external package, found in recipes/
     clean         Clean the build
     distclean     Clean the build and the result
     recipes       List all the available recipes

--- a/toolchain.py
+++ b/toolchain.py
@@ -1060,7 +1060,7 @@ if __name__ == "__main__":
                     usage="""toolchain <command> [<args>]
                     
 Available commands:
-    build         Build an external package, found in recipes/
+    build         Build an external package (available packages in the recipes directory).
     clean         Clean the build
     distclean     Clean the build and the result
     recipes       List all the available recipes


### PR DESCRIPTION
I wanted to run NumPy on iOS, but had no previous experience with kivy-ios. I looked at the docs, but it didn't jump out to me that I had to run these commands to get NumPy ready for iOS:

``` shell
./toolchain.py build numpy
./toolchain.py update <path-to-xcodeproj>
```