### PR TITLE
Update python loader to load from frameworks as well as main exe (i.e…

### DIFF
--- a/recipes/python/dynload.patch
+++ b/recipes/python/dynload.patch
@@ -10,7 +10,7 @@
 +	 * of trying to dlopen, directly do the dlsym.
 +	 * -- Mathieu
 +	 */
-+    return (dl_funcptr) dlsym(RTLD_MAIN_ONLY, funcname);
++    return (dl_funcptr) dlsym(RTLD_SELF, funcname);
 +
 +#if 0
      if (fp != NULL) {


### PR DESCRIPTION
Add support for embedding kivy in a dynamic framework. This allows us to correctly load the python modules from the sub dl instead of the main exe 
