### PR TITLE
Fix missing parentheses at 2 lines in toolchain.py

### DIFF
--- a/toolchain.py
+++ b/toolchain.py
@@ -1076,7 +1076,7 @@ Xcode:
             parser.add_argument("command", help="Command to run")
             args = parser.parse_args(sys.argv[1:2])
             if not hasattr(self, args.command):
-                print 'Unrecognized command'
+                print('Unrecognized command')
                 parser.print_help()
                 exit(1)
             getattr(self, args.command)()
@@ -1244,7 +1244,7 @@ Xcode:
                 "PYTHONOPTIMIZE": "2",
                 "PIP_INSTALL_TARGET": ctx.site_packages_dir
             }
-            print pip_env
+            print(pip_env)
             pip_path = sh.which("pip")
             args = [pip_path] + sys.argv[2:]
             if not pip_path:


### PR DESCRIPTION
This was causing errors with python 3.5 on OSX