### PR TITLE
stdout fix for iOS 10 debugging

### DIFF
--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -121,13 +121,6 @@ void load_custom_builtin_importer() {
         "import sys, imp\n" \
         "from os import environ\n" \
         "from os.path import exists, join\n" \
-        "# Fake redirection when we run the app without xcode\n" \
-        "if 'CFLOG_FORCE_STDERR' not in environ:\n" \
-        "    class fakestd(object):\n" \
-        "        def write(self, *args, **kw): pass\n" \
-        "        def flush(self, *args, **kw): pass\n" \
-        "    sys.stdout = fakestd()\n" \
-        "    sys.stderr = fakestd()\n" \
         "# Custom builtin importer for precompiled modules\n" \
         "class CustomBuiltinImporter(object):\n" \
         "    def find_module(self, fullname, mpath=None):\n" \

--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -123,7 +123,6 @@ void load_custom_builtin_importer() {
         "from os.path import exists, join\n" \
         "# Fake redirection to supress console output\n" \
         "if environ.get('KIVY_NO_CONSOLE', '0') == '1':\n" \
-        "    print('Killing console. Remove me!')\n" \
         "    class fakestd(object):\n" \
         "        def write(self, *args, **kw): pass\n" \
         "        def flush(self, *args, **kw): pass\n" \

--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -121,6 +121,14 @@ void load_custom_builtin_importer() {
         "import sys, imp\n" \
         "from os import environ\n" \
         "from os.path import exists, join\n" \
+        "# Fake redirection to supress console output\n" \
+        "if environ.get('KIVY_NO_CONSOLE', '0') == '1':\n" \
+        "    print('Killing console. Remove me!')\n" \
+        "    class fakestd(object):\n" \
+        "        def write(self, *args, **kw): pass\n" \
+        "        def flush(self, *args, **kw): pass\n" \
+        "    sys.stdout = fakestd()\n" \
+        "    sys.stderr = fakestd()\n" \
         "# Custom builtin importer for precompiled modules\n" \
         "class CustomBuiltinImporter(object):\n" \
         "    def find_module(self, fullname, mpath=None):\n" \


### PR DESCRIPTION
The removed code prevents logging on iOS 10 and above. It seems to be redundant as it claims to help a running without XCode, but it's part of the XCode project template? It's supposed to run it XCode, so why is it there?

See https://github.com/kivy/pyobjus/issues/36 for discussion.