### PR TITLE
Clean up temp files before urlretrieve

### DIFF
--- a/toolchain.py
+++ b/toolchain.py
@@ -19,9 +19,9 @@ import shutil
 import fnmatch
 from datetime import datetime
 try:
-    from urllib.request import FancyURLopener
+    from urllib.request import FancyURLopener, urlcleanup
 except ImportError:
-    from urllib import FancyURLopener
+    from urllib import FancyURLopener, urlcleanup
 
 curdir = dirname(__file__)
 sys.path.insert(0, join(curdir, "tools", "external"))
@@ -409,6 +409,9 @@ class Recipe(object):
             filename = join(cwd, filename)
         if exists(filename):
             unlink(filename)
+
+        # Clean up temporary files just in case before downloading.
+        urlcleanup()
 
         print('Downloading {0}'.format(url))
         urlretrieve(url, filename, report_hook)


### PR DESCRIPTION
Earlier, when I ran the `./toolchain build kivy` command, I got the following error:
```python
...
IOError: [Errno ftp error] 200 Type set to I
```
This error was traced back to the `urlretrieve` call, and after some searching on SO, I found the following, simple solution <a href="http://stackoverflow.com/questions/39518975/when-trying-to-install-lxml-in-python-get-error-ftp-error-200-type-set-to-i">here</a>.  I applied the change, and everything worked just fine again.

Even if this error is not occurring for other users, I don't think this addition can hurt that much and might save some headache for others in the future who could run into this problem like I did.