### PR TITLE
The recipe don't download the archive.

### DIFF
--- a/recipes/libpng/__init__.py
+++ b/recipes/libpng/__init__.py
@@ -4,8 +4,8 @@ from os.path import join
 import sh
 
 class PngRecipe(Recipe):
-    version = '1.6.24'
-    url = 'http://vorboss.dl.sourceforge.net/project/libpng/libpng16/1.6.24/libpng-1.6.24.tar.gz'
+    version = '1.6.26'
+    url = 'http://downloads.sourceforge.net/sourceforge/libpng/libpng-{version}.tar.gz'
     depends = ["python"]
     library = '.libs/libpng16.a'
 


### PR DESCRIPTION
If I try download the archive manually, this url "http://vorboss.dl.sourceforge.net/project/libpng/libpng16/1.6.24/libpng-1.6.24.tar.gz" redirect to "https://sourceforge.net/projects/libpng/files/"

...
Extract libpng
Extract libpng for i386
Traceback (most recent call last):
  File "./toolchain.py", line 1311, in <module>
    ToolchainCL()
  File "./toolchain.py", line 1082, in __init__
    getattr(self, args.command)()
  File "./toolchain.py", line 1106, in build
    build_recipes(args.recipe, ctx)
  File "./toolchain.py", line 974, in build_recipes
    recipe.execute()
  File "/Users/prrcarvalho/Development/kivy-ios-master/toolchain.py", line 585, in execute
    self.extract()
  File "/Users/prrcarvalho/Development/kivy-ios-master/toolchain.py", line 56, in _cache_execution
    f(self, *args, **kwargs)
  File "/Users/prrcarvalho/Development/kivy-ios-master/toolchain.py", line 621, in extract
    self.extract_arch(arch.arch)
  File "/Users/prrcarvalho/Development/kivy-ios-master/toolchain.py", line 625, in extract_arch
    dest_dir = join(build_dir, self.archive_root)
  File "/Users/prrcarvalho/Development/kivy-ios-master/toolchain.py", line 577, in archive_root
    value = self.get_archive_rootdir(self.archive_fn)
  File "/Users/prrcarvalho/Development/kivy-ios-master/toolchain.py", line 442, in get_archive_rootdir
    archive = tarfile.open(filename)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 1673, in open
    return func(name, "r", fileobj, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 1738, in gzopen
    fileobj = gzip.GzipFile(name, mode, compresslevel, fileobj)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/gzip.py", line 94, in __init__
    fileobj = self.myfileobj = __builtin__.open(filename, mode or 'rb')
IOError: [Errno 2] No such file or directory: '/Users/prrcarvalho/Development/kivy-ios-master/.cache/libpng-libpng-1.6.24.tar.gz'