### PR TITLE
Turn relative path to absolute path for kivy directory

### DIFF
--- a/toolchain.py
+++ b/toolchain.py
@@ -1185,6 +1185,7 @@ Xcode:
                 "title": args.name,
                 "project_name": args.name.lower(),
                 "domain_name": "org.kivy.{}".format(args.name.lower()),
+                "kivy_dir": dirname(realpath(__file__)),
                 "project_dir": realpath(args.directory),
                 "version": "1.0.0",
                 "dist_dir": ctx.dist_dir,

--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -5,8 +5,8 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#include "../dist/root/python/include/python2.7/Python.h"
-#include "../dist/include/common/sdl2/SDL_main.h"
+#include "{{ cookiecutter.kivy_dir }}/dist/root/python/include/python2.7/Python.h"
+#include "{{ cookiecutter.kivy_dir }}/dist/include/common/sdl2/SDL_main.h"
 #include <dlfcn.h>
 
 void export_orientation();


### PR DESCRIPTION
Makes the directory path to the `kivy-ios` directory absolute rather than relative, which makes the project exportable.  Resolves one of the major issues described on the <a href="https://kivy.org/docs/guide/packaging-ios.html">website</a>.