### PR TITLE
add concurrent make, xcodebuild, gzip/bzip2

### DIFF
--- a/recipes/ffmpeg/__init__.py
+++ b/recipes/ffmpeg/__init__.py
@@ -85,7 +85,7 @@ class FFMpegRecipe(Recipe):
                     "config.asm")
         """
         shprint(sh.make, "clean", _env=build_env)
-        shprint(sh.make, "-j4", _env=build_env)
+        shprint(sh.make, self.ctx.concurrent_make, _env=build_env)
         shprint(sh.make, "install")
 
 

--- a/recipes/freetype/__init__.py
+++ b/recipes/freetype/__init__.py
@@ -28,7 +28,7 @@ class FreetypeRecipe(Recipe):
                 "--enable-static=yes",
                 "--enable-shared=no")
         shprint(sh.make, "clean")
-        shprint(sh.make)
+        shprint(sh.make, self.ctx.concurrent_make)
 
 
 recipe = FreetypeRecipe()

--- a/recipes/hostlibffi/__init__.py
+++ b/recipes/hostlibffi/__init__.py
@@ -34,7 +34,7 @@ class LibffiRecipe(Recipe):
         self.set_marker("patched")
 
     def build_arch(self, arch):
-        shprint(sh.xcodebuild,
+        shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(arch.arch),
                 "-sdk", "macosx",

--- a/recipes/hostpython/__init__.py
+++ b/recipes/hostpython/__init__.py
@@ -73,7 +73,7 @@ class HostpythonRecipe(Recipe):
                 "--disable-toolbox-glue",
                 "--without-gcc",
                 _env=build_env)
-        shprint(sh.make, "-C", self.build_dir, "-j4", "python", "Parser/pgen",
+        shprint(sh.make, "-C", self.build_dir, self.ctx.concurrent_make, "python", "Parser/pgen",
                 _env=build_env)
         shutil.move("python", "hostpython")
         shutil.move("Parser/pgen", "Parser/hostpgen")
@@ -88,7 +88,7 @@ class HostpythonRecipe(Recipe):
         shprint(sh.ln, "-s",
                 join(build_dir, "hostpython"),
                 join(build_dir, "Python"))
-        shprint(sh.make,
+        shprint(sh.make, self.ctx.concurrent_make,
                 "-C", build_dir,
                 "bininstall", "inclinstall",
                 _env=build_env)

--- a/recipes/libffi/__init__.py
+++ b/recipes/libffi/__init__.py
@@ -23,7 +23,7 @@ class LibffiRecipe(Recipe):
         self.set_marker("patched")
 
     def build_arch(self, arch):
-        shprint(sh.xcodebuild,
+        shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(arch.arch),
                 "-sdk", arch.sdk,

--- a/recipes/libjpeg/__init__.py
+++ b/recipes/libjpeg/__init__.py
@@ -29,7 +29,7 @@ class JpegRecipe(Recipe):
                 "--host={}".format(arch.triple),
                 "--disable-shared")
         shprint(sh.make, "clean")
-        shprint(sh.make)
+        shprint(sh.make, self.ctx.concurrent_make)
 
 recipe = JpegRecipe()
 

--- a/recipes/libpng/__init__.py
+++ b/recipes/libpng/__init__.py
@@ -21,6 +21,6 @@ class PngRecipe(Recipe):
                 "--host={}".format(arch.triple),
                 "--disable-shared")
         shprint(sh.make, "clean")
-        shprint(sh.make, _env=build_env)
+        shprint(sh.make, self.ctx.concurrent_make, _env=build_env)
 
 recipe = PngRecipe()

--- a/recipes/openssl/__init__.py
+++ b/recipes/openssl/__init__.py
@@ -43,6 +43,6 @@ class OpensslRecipe(Recipe):
             sh.sed("-ie", "s!^CFLAG=!CFLAG={} !".format(build_env['CFLAGS']),
                    "Makefile")
         shprint(sh.make, "clean")
-        shprint(sh.make, "-j4", "build_libs")
+        shprint(sh.make, self.ctx.concurrent_make, "build_libs")
 
 recipe = OpensslRecipe()

--- a/recipes/python/__init__.py
+++ b/recipes/python/__init__.py
@@ -56,7 +56,7 @@ class PythonRecipe(Recipe):
         self.apply_patch("ctypes_duplicate.patch")
         self.apply_patch("ctypes_duplicate_longdouble.patch")
 
-        shprint(sh.make, "-j4",
+        shprint(sh.make, self.ctx.concurrent_make,
                 "CROSS_COMPILE_TARGET=yes",
                 "HOSTPYTHON={}".format(self.ctx.hostpython),
                 "HOSTPGEN={}".format(self.ctx.hostpgen))
@@ -66,7 +66,7 @@ class PythonRecipe(Recipe):
         build_env = arch.get_env()
         build_dir = self.get_build_dir(arch.arch)
         build_env["PATH"] = os.environ["PATH"]
-        shprint(sh.make,
+        shprint(sh.make, self.ctx.concurrent_make,
                 "-C", build_dir,
                 "install",
                 "CROSS_COMPILE_TARGET=yes",

--- a/recipes/sdl2/__init__.py
+++ b/recipes/sdl2/__init__.py
@@ -20,7 +20,7 @@ class LibSDL2Recipe(Recipe):
 
     def build_arch(self, arch):
         env = arch.get_env()
-        shprint(sh.xcodebuild,
+        shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(arch.arch),
                 "CC={}".format(env['CC']),

--- a/recipes/sdl2_image/__init__.py
+++ b/recipes/sdl2_image/__init__.py
@@ -12,7 +12,7 @@ class LibSDL2ImageRecipe(Recipe):
     pbx_frameworks = ["CoreGraphics", "MobileCoreServices"]
 
     def build_arch(self, arch):
-        shprint(sh.xcodebuild,
+        shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(arch.arch),
                 "HEADER_SEARCH_PATHS={}".format(

--- a/recipes/sdl2_mixer/__init__.py
+++ b/recipes/sdl2_mixer/__init__.py
@@ -12,7 +12,7 @@ class LibSDL2MixerRecipe(Recipe):
     pbx_libraries = ["libc++"]
 
     def build_arch(self, arch):
-        shprint(sh.xcodebuild,
+        shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(arch.arch),
                 "HEADER_SEARCH_PATHS=$HEADER_SEARCH_PATHS {}".format(" ".join(arch.include_dirs)),


### PR DESCRIPTION
Enables concurrent make and xcodebuild for relevant recipes, adds support for multicore decompressing with pigz and pbzip2. Number of jobs defaults to the number of cores, but can be overridden on the command line. pigz and pbzip2 can also be disabled via the command line.