### PR TITLE
Make webview window size customizable

### DIFF
--- a/recipes/ios/src/ios.pyx
+++ b/recipes/ios/src/ios.pyx
@@ -14,7 +14,7 @@ cdef extern from "ios_wrapper.h":
     int ios_send_email(char *subject, char *text, char *mimetype, char
             *filename, char *filename_alias, ios_send_email_cb cb, void *userdata)
     void ios_open_url(char *url)
-    void load_url_webview(char *url)
+    void load_url_webview(char *url, int width, int height)
     float ios_uiscreen_get_scale()
     int ios_uiscreen_get_dpi()
 
@@ -27,11 +27,11 @@ cdef void _send_email_done(char *status, void *data):
 #Support for iOS webview
 #
 class IOSWebView(object):
-    def open(self, url):
-        open_url_wbv(url)
+    def open(self, url, width, height):
+        open_url_wbv(url, width, height)
         
 
-def open_url_wbv(url):
+def open_url_wbv(url, width, height):
     '''
     OPEN URL in webview
 
@@ -39,13 +39,19 @@ def open_url_wbv(url):
         `url`: str
             URL string
 
+        `height`: int
+            Height of the window
+
+        `width`: int
+            Width of the window
+
     Example for opening up a web page in UIWebview::
 
         import ios
         url = "http://www.google.com"
-        ios.IOSWebView().open(url)
+        ios.IOSWebView().open(url, width, height)
     '''
-    load_url_webview(url)
+    load_url_webview(url, width, height)
 
 #
 # Support for webbrowser module

--- a/recipes/ios/src/ios_browser.m
+++ b/recipes/ios/src/ios_browser.m
@@ -15,10 +15,10 @@ void ios_open_url(char *url)
 /*
  * Webview support
  */
-void load_url_webview(char *url)
+void load_url_webview(char *url, int width, int height)
 {
     NSString *nsurl = [NSString stringWithCString:(char *)url encoding:NSUTF8StringEncoding];
-    UIWebView *webView = [[UIWebView alloc] initWithFrame: CGRectMake(0, 0, 320, 480)];
+    UIWebView *webView = [[UIWebView alloc] initWithFrame: CGRectMake(0, 0, width, height)];
     UIWindow *window = [[UIApplication sharedApplication] keyWindow];
     UIView *view = [window.rootViewController view];
     [view addSubview:webView];

--- a/recipes/ios/src/ios_wrapper.h
+++ b/recipes/ios/src/ios_wrapper.h
@@ -4,7 +4,7 @@
 float ios_uiscreen_get_scale(void);
 int ios_uiscreen_get_dpi(void);
 void ios_open_url(char *url);
-void load_url_webview(char *url);
+void load_url_webview(char *url, int width, int height);
 
 typedef void (*ios_send_email_cb)(char *, void *);
 


### PR DESCRIPTION
Webview window size can now be passed as a parameter to `open` function of IOSWebview.