### PR TITLE
Fixing compilation problems on osx 10.12 with xcode 9.

### DIFF
--- a/recipes/hostpython/__init__.py
+++ b/recipes/hostpython/__init__.py
@@ -60,6 +60,8 @@ class HostpythonRecipe(Recipe):
                 ])
         build_env["CFLAGS"] = " ".join([
                 "--sysroot={}".format(sdk_path),
+                "-arch x86_64",
+                "-mmacosx-version-min=10.12",
                 "-I{}".format(join(self.ctx.dist_dir, "hostlibffi", "usr", "local", "include"))
                 ])
 

--- a/recipes/python/__init__.py
+++ b/recipes/python/__init__.py
@@ -35,6 +35,7 @@ class PythonRecipe(Recipe):
         self.apply_patch("ipv6.patch")
         if "openssl.build_all" in self.ctx.state:
              self.append_file("ModulesSetup.openssl", "Modules/Setup.local")
+        self.apply_patch("posixmodule.patch")
 
         self.set_marker("patched")
 

--- a/recipes/python/posixmodule.patch
+++ b/recipes/python/posixmodule.patch
@@ -1,0 +1,16 @@
+Index: Python-2.7.1/Modules/posixmodule.c
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- Python-2.7.1/Modules/posixmodule.c	(date 1290868829000)
++++ Python-2.7.1/Modules/posixmodule.c	(revision )
+@@ -2644,7 +2644,7 @@
+ #endif
+ }
+ 
+-
++#undef HAVE_SYSTEM
+ #ifdef HAVE_SYSTEM
+ PyDoc_STRVAR(posix_system__doc__,
+ "system(command) -> exit_status\n\n\


### PR DESCRIPTION
*Important Note:
When the xcode project is created, in order to get kivy working you have to manually add the following framewors:
- CoreMotion
- libz
- libsqlite3