### PR TITLE
Fix unicode error introduced in latest macOS

### DIFF
--- a/toolchain.py
+++ b/toolchain.py
@@ -37,7 +37,7 @@ def shprint(command, *args, **kwargs):
     kwargs["_out_bufsize"] = 1
     kwargs["_err_to_out"] = True
     for line in command(*args, **kwargs):
-        stdout.write(line)
+        stdout.write(line.encode("ascii", "replace").decode())
 
 
 def cache_execution(f):


### PR DESCRIPTION
This little change fixes an error I noticed popping up on the latest macOS update.
When building anything, either via buildozer or straight from the project, toolchain.py provided the following error:
```
Traceback (most recent call last):
  File "./toolchain.py", line 1365, in <module>
    ToolchainCL()
  File "./toolchain.py", line 1114, in __init__
    getattr(self, args.command)()
  File "./toolchain.py", line 1155, in build
    build_recipes(args.recipe, ctx)
  File "./toolchain.py", line 1005, in build_recipes
    recipe.execute()
  File "/Users/cruor/code/sadpandareader/app/.buildozer/ios/platform/kivy-ios/toolchain.py", line 615, in execute
    self.build_all()
  File "/Users/cruor/code/sadpandareader/app/.buildozer/ios/platform/kivy-ios/recipes/hostlibffi/__init__.py", line 19, in build_all
    self.build(arch)
  File "/Users/cruor/code/sadpandareader/app/.buildozer/ios/platform/kivy-ios/toolchain.py", line 56, in _cache_execution
    f(self, *args, **kwargs)
  File "/Users/cruor/code/sadpandareader/app/.buildozer/ios/platform/kivy-ios/toolchain.py", line 691, in build
    self.build_arch(arch)
  File "/Users/cruor/code/sadpandareader/app/.buildozer/ios/platform/kivy-ios/recipes/hostlibffi/__init__.py", line 45, in build_arch
    "DSTROOT={}/hostlibffi".format(self.ctx.dist_dir))
  File "/Users/cruor/code/sadpandareader/app/.buildozer/ios/platform/kivy-ios/toolchain.py", line 40, in shprint
    stdout.write(line)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 116: ordinal not in range(128)
# Command failed: ./toolchain.py build kivy openssl plyer
#
# Buildozer failed to execute the last command
# The error might be hidden in the log above this error
# Please read the full log, and search for it before
# raising an issue with buildozer itself.
# In case of a bug report, please add a full log with log_level = 2
```

This little fix seems to clear that issue, by simply replacing the ascii in the output with ?.
I am not aware of any issues reporting this.
This does not seem to affect any actual compilation process, only the terminal output while compiling.