### PR TITLE
Fix typo in mod_pbxproj.py

### DIFF
--- a/tools/external/mod_pbxproj.py
+++ b/tools/external/mod_pbxproj.py
@@ -1291,7 +1291,7 @@ class XcodeProject(PBXDict):
                     out.write(' ')
 
             try:
-                iterKeys = root.iterkeys()
+                iterkeys = root.iterkeys()
 
             except:
                 # python 3 support


### PR DESCRIPTION
Noticed that after the most recent merged pull requests, a typo was introduced in mod_pbxproj.py.
A similar issue has been raised here: #294
