### PR TITLE
Improve frameworks support to prepare for buildozer use

### DIFF
--- a/toolchain.py
+++ b/toolchain.py
@@ -1332,6 +1332,7 @@ Xcode:
                     description="Create a new xcode project")
             parser.add_argument("name", help="Name of your project")
             parser.add_argument("directory", help="Directory where your project lives")
+            parser.add_argument("--add-framework", action="append", help="Additional Frameworks to include with this project")
             args = parser.parse_args(sys.argv[2:])
 
             from cookiecutter.main import cookiecutter
@@ -1362,7 +1363,7 @@ Xcode:
                     "{}-ios".format(args.name.lower()),
                     "{}.xcodeproj".format(args.name.lower()),
                     "project.pbxproj")
-            update_pbxproj(filename)
+            update_pbxproj(filename, pbx_frameworks=args.add_framework)
             print("--")
             print("Project directory : {}-ios".format(
                 args.name.lower()))
@@ -1373,7 +1374,7 @@ Xcode:
             parser = argparse.ArgumentParser(
                     description="Update an existing xcode project")
             parser.add_argument("filename", help="Path to your project or xcodeproj")
-            parser.add_argument("--add-frameworks", nargs="*", help="Frameworks to add to this project")
+            parser.add_argument("--add-framework", action="append", help="Additional Frameworks to include with this project")
             args = parser.parse_args(sys.argv[2:])
 
             filename = args.filename
@@ -1391,7 +1392,7 @@ Xcode:
                 print("ERROR: {} not found".format(filename))
                 sys.exit(1)
 
-            update_pbxproj(filename, pbx_frameworks=args.add_frameworks)
+            update_pbxproj(filename, pbx_frameworks=args.add_framework)
             print("--")
             print("Project {} updated".format(filename))
 


### PR DESCRIPTION
In working on a PR to add framework support to buildozer, I noticed two ways I could improve
the feature merged in https://github.com/kivy/kivy-ios/pull/339

First, change the flag to to 'append' type (less confusing to add multiple libraries). 

Second, change name of the flag to `--add-framework` (singular), as the flag must now be specified once per additional framework.

