### PR TITLE
enable plyer on arm64

### DIFF
--- a/recipes/plyer/__init__.py
+++ b/recipes/plyer/__init__.py
@@ -4,7 +4,7 @@ class PlyerRecipe(PythonRecipe):
     version = "master"
     url = "https://github.com/kivy/plyer/archive/{version}.zip"
     depends = ["python", "pyobjus"]
-    archs = ["x86_64"]
+    archs = ["x86_64", "arm64"]
 
 
 recipe = PlyerRecipe()


### PR DESCRIPTION
I can't think of why we wouldn't want plyer to work on an ios device (in fact, I *need* plyer to be compiled for an ios device)