### PR TITLE
Use python logging infrastructure

### DIFF
--- a/recipes/hostlibffi/__init__.py
+++ b/recipes/hostlibffi/__init__.py
@@ -1,7 +1,9 @@
 from toolchain import Recipe, shprint
 import sh
 from os.path import exists
+import logging
 
+logger = logging.getLogger(__name__)
 
 class LibffiRecipe(Recipe):
     version = "3.2.1"
@@ -13,7 +15,7 @@ class LibffiRecipe(Recipe):
 
     def build_all(self):
         filtered_archs = self.filtered_archs
-        print("Build {} for {} (filtered)".format(
+        logger.info("Build {} for {} (filtered)".format(
             self.name,
             ", ".join([x.arch for x in filtered_archs])))
         for arch in self.filtered_archs:

--- a/recipes/hostpython.py
+++ b/recipes/hostpython.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import sys
 from toolchain import Recipe
+import logging
+
+logger = logging.getLogger(__name__)
 
 class HostpythonAliasRecipe(Recipe):
     is_alias = True
@@ -14,11 +17,9 @@ class HostpythonAliasRecipe(Recipe):
             elif "hostpython3" in ctx.wanted_recipes:
                 hostpython = "hostpython3"
             else:
-                print("")
-                print("ERROR: No hostpython version set in the build.")
-                print("ERROR: Add python2 or python3 in your recipes:")
-                print("ERROR: ./toolchain.py build python3 ...")
-                print("")
+                logger.error("No hostpython version set in the build.")
+                logger.error("Add python2 or python3 in your recipes:")
+                logger.error("./toolchain.py build python3 ...")
                 sys.exit(1)
         if hostpython:
             self.depends = [hostpython]

--- a/recipes/hostpython2/__init__.py
+++ b/recipes/hostpython2/__init__.py
@@ -3,6 +3,9 @@ from os.path import join, exists
 import os
 import sh
 import shutil
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Hostpython2Recipe(Recipe):
@@ -18,8 +21,8 @@ class Hostpython2Recipe(Recipe):
         self.ctx.so_suffix = ".so"
         self.ctx.hostpython = join(self.ctx.dist_dir, "hostpython2", "bin", "python")
         self.ctx.hostpgen = join(self.ctx.dist_dir, "hostpython2", "bin", "pgen")
-        print("Global: hostpython located at {}".format(self.ctx.hostpython))
-        print("Global: hostpgen located at {}".format(self.ctx.hostpgen))
+        logger.info("Global: hostpython located at {}".format(self.ctx.hostpython))
+        logger.info("Global: hostpgen located at {}".format(self.ctx.hostpgen))
 
     def prebuild_arch(self, arch):
         if self.has_marker("patched"):

--- a/recipes/hostpython3/__init__.py
+++ b/recipes/hostpython3/__init__.py
@@ -3,6 +3,9 @@ from os.path import join, exists
 import os
 import sh
 import shutil
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Hostpython3Recipe(Recipe):
@@ -18,8 +21,8 @@ class Hostpython3Recipe(Recipe):
         self.ctx.so_suffix = ".cpython-37m-darwin.so"
         self.ctx.hostpython = join(self.ctx.dist_dir, "hostpython3", "bin", "python")
         self.ctx.hostpgen = join(self.ctx.dist_dir, "hostpython3", "bin", "pgen")
-        print("Global: hostpython located at {}".format(self.ctx.hostpython))
-        print("Global: hostpgen located at {}".format(self.ctx.hostpgen))
+        logger.info("Global: hostpython located at {}".format(self.ctx.hostpython))
+        logger.info("Global: hostpgen located at {}".format(self.ctx.hostpgen))
 
     def prebuild_arch(self, arch):
         if self.has_marker("patched"):

--- a/recipes/kivent_core/__init__.py
+++ b/recipes/kivent_core/__init__.py
@@ -7,7 +7,9 @@ from toolchain import CythonRecipe, shprint
 import sh
 from os.path import join
 from os import environ, chdir
+import logging
 
+logger = logging.getLogger(__name__)
 
 
 class KiventCoreRecipe(CythonRecipe):
@@ -36,10 +38,10 @@ class KiventCoreRecipe(CythonRecipe):
         builddir = super(KiventCoreRecipe, self).get_build_dir(str(arch))
         if sub or self.subbuilddir:
             core_build_dir = join (builddir, 'modules', 'core')
-            print "Core build directory is located at {}".format(core_build_dir)
+            logger.info("Core build directory is located at {}".format(core_build_dir))
             return core_build_dir
         else:
-            print "Building in {}".format(builddir)
+            logger.info("Building in {}".format(builddir))
             return builddir
 
 
@@ -72,7 +74,7 @@ class KiventCoreRecipe(CythonRecipe):
         arch = list(self.filtered_archs)[0]
 
         build_dir = self.get_build_dir(arch.arch,sub=True)
-        print "Building kivent_core {} in {}".format(arch.arch,build_dir)
+        logger.info("Building kivent_core {} in {}".format(arch.arch,build_dir))
         chdir(build_dir)
         hostpython = sh.Command(self.ctx.hostpython)
 
@@ -93,12 +95,12 @@ class KiventCoreRecipe(CythonRecipe):
 
 
         #Print out directories for sanity check
-        print "ENVS", build_env
-        print "ROOT",self.ctx.root_dir
-        print "BUILD",self.ctx.build_dir
-        print "INCLUDE", self.ctx.include_dir
-        print "DISTDIR", self.ctx.dist_dir
-        print "ARCH KIVY LOC",self.get_recipe('kivy', self.ctx).get_build_dir(arch.arch)
+        logger.info("ENVS", build_env)
+        logger.info("ROOT",self.ctx.root_dir)
+        logger.info("BUILD",self.ctx.build_dir)
+        logger.info("INCLUDE", self.ctx.include_dir)
+        logger.info("DISTDIR", self.ctx.dist_dir)
+        logger.info("ARCH KIVY LOC",self.get_recipe('kivy', self.ctx).get_build_dir(arch.arch))
 
         shprint(hostpython, setup_path, "build_ext", "install", _env=build_env)
 

--- a/recipes/python.py
+++ b/recipes/python.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import sys
 from toolchain import Recipe
+import logging
+
+logger = logging.getLogger(__name__)
 
 class PythonAliasRecipe(Recipe):
     is_alias = True
@@ -14,11 +17,9 @@ class PythonAliasRecipe(Recipe):
             elif "python3" in ctx.wanted_recipes:
                 python = "python3"
             else:
-                print("")
-                print("ERROR: No Python version set in the build.")
-                print("ERROR: Add python2 or python3 in your recipes:")
-                print("ERROR: ./toolchain.py build python3 ...")
-                print("")
+                logger.error("No Python version set in the build.")
+                logger.error("Add python2 or python3 in your recipes:")
+                logger.error("./toolchain.py build python3 ...")
                 sys.exit(1)
         if python:
             self.depends = [python]

--- a/recipes/python2/__init__.py
+++ b/recipes/python2/__init__.py
@@ -2,7 +2,9 @@ from toolchain import Recipe, shprint
 from os.path import join
 import sh
 import os
+import logging
 
+logger = logging.getLogger(__name__)
 
 class Python2Recipe(Recipe):
     version = "2.7.1"
@@ -115,10 +117,10 @@ class Python2Recipe(Recipe):
             fd.writelines(lines)
 
     def reduce_python(self):
-        print("Reduce python")
+        logger.info("Reduce python")
         oldpwd = os.getcwd()
         try:
-            print("Remove files unlikely to be used")
+            logger.info("Remove files unlikely to be used")
             os.chdir(join(self.ctx.dist_dir, "root", "python2"))
             sh.rm("-rf", "share")
             sh.rm("-rf", "bin")
@@ -133,7 +135,7 @@ class Python2Recipe(Recipe):
             sh.rm("-rf", sh.glob("lib*"))
 
             # now create the zip.
-            print("Create a python27.zip")
+            logger.info("Create a python27.zip")
             sh.rm("config/libpython2.7.a")
             sh.rm("config/python.o")
             sh.rm("config/config.c.in")

--- a/recipes/python3/__init__.py
+++ b/recipes/python3/__init__.py
@@ -3,6 +3,9 @@ from os.path import join
 import sh
 import shutil
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Python3Recipe(Recipe):
@@ -104,10 +107,10 @@ class Python3Recipe(Recipe):
         self.reduce_python()
 
     def reduce_python(self):
-        print("Reduce python")
+        logger.info("Reduce python")
         oldpwd = os.getcwd()
         try:
-            print("Remove files unlikely to be used")
+            logger.info("Remove files unlikely to be used")
             os.chdir(join(self.ctx.dist_dir, "root", "python3"))
             # os.execve("/bin/bash", ["/bin/bash"], env=os.environ)
             sh.rm("-rf", "bin", "share")
@@ -150,7 +153,7 @@ class Python3Recipe(Recipe):
             sh.find(".", "-name", "__pycache__", "-type", "d", "-delete")
 
             # create the lib zip
-            print("Create a python3.7.zip")
+            logger.info("Create a python3.7.zip")
             sh.mv("config-3.7m-darwin", "..")
             sh.mv("site-packages", "..")
             sh.zip("-r", "../python37.zip", sh.glob("*"))

--- a/toolchain.py
+++ b/toolchain.py
@@ -881,7 +881,9 @@ class Recipe(object):
         """
         key_time = "{}.at".format(key)
         self.ctx.state[key] = value
-        self.ctx.state[key_time] = str(datetime.utcnow())
+        now_str = str(datetime.utcnow())
+        self.ctx.state[key_time] = now_str
+        logger.debug("New State: {} at {}".format(key, now_str))
 
     @cache_execution
     def make_lipo(self, filename, library=None):
@@ -904,12 +906,13 @@ class Recipe(object):
         arch = self.filtered_archs[0]
         build_dir = self.get_build_dir(arch.arch)
         for framework in self.frameworks:
-            logger.info(" - Install {}".format(framework))
+            logger.info("Install Framework {}".format(framework))
             src = join(build_dir, framework)
             dest = join(self.ctx.dist_dir, "frameworks", framework)
             ensure_dir(dirname(dest))
             if exists(dest):
                 shutil.rmtree(dest)
+            logger.debug("Copy {} to {}".format(src, dest))
             shutil.copytree(src, dest)
 
     @cache_execution
@@ -919,12 +922,13 @@ class Recipe(object):
         arch = self.filtered_archs[0]
         build_dir = self.get_build_dir(arch.arch)
         for source in self.sources:
-            logger.info(" - Install {}".format(source))
+            logger.info("Install Sources{}".format(source))
             src = join(build_dir, source)
             dest = join(self.ctx.dist_dir, "sources", self.name)
             ensure_dir(dirname(dest))
             if exists(dest):
                 shutil.rmtree(dest)
+            logger.debug("Copy {} to {}".format(src, dest))
             shutil.copytree(src, dest)
 
     @cache_execution
@@ -962,7 +966,7 @@ class Recipe(object):
                     shutil.copytree(src_dir, dest_dir)
                 else:
                     dest = join(dest_dir, dest_name)
-                    logger.info("Copy {} to {}".format(src_dir, dest))
+                    logger.info("Copy Include {} to {}".format(src_dir, dest))
                     ensure_dir(dirname(dest))
                     shutil.copy(src_dir, dest)
 

--- a/toolchain.py
+++ b/toolchain.py
@@ -39,7 +39,9 @@ import sh
 
 import logging
 
-logging.basicConfig(format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(funcName)s():%(lineno)d] %(message)s',
+# For more detailed logging, use something like
+# format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(funcName)s():%(lineno)d] %(message)s'
+logging.basicConfig(format='[%(levelname)-8s] %(message)s',
                     datefmt='%Y-%m-%d:%H:%M:%S',
                     level=logging.DEBUG)
 


### PR DESCRIPTION
This is an attempt converting all the logging, warning, and error-style print statements in kivy-ios to use the python logging infrastructure instead. I've been running with it for a month or two at this point, and I've adjusted the levels to correspond to where I think they make sense. (opinions may differ here)

This also solves an irritating issue where the output of `shprint()` would get randomly interleaved with the python print statements (because of differences in flushing between `stdout.write()` and `print()`), making debugging more difficult. 

