### PR TITLE
Add gif to KIVY_IMAGE in template

### DIFF
--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     putenv("KIVY_NO_CONFIG=1");
     putenv("KIVY_NO_FILELOG=1");
     putenv("KIVY_WINDOW=sdl2");
-    putenv("KIVY_IMAGE=imageio,tex");
+    putenv("KIVY_IMAGE=imageio,tex,gif");
     putenv("KIVY_AUDIO=sdl2");
     putenv("KIVY_GL_BACKEND=sdl2");
     #ifndef DEBUG


### PR DESCRIPTION
Adds `gif` to `main.m` in `cookiecutter` template.

gifs are currently used by `kivy` (Ex: `AsyncImage` loading spinner), so I think We should add `gif` provider by default.