### PR TITLE
Update ffmpeg and ffpyplayer recipes

### DIFF
--- a/recipes/ffmpeg/__init__.py
+++ b/recipes/ffmpeg/__init__.py
@@ -4,8 +4,8 @@ import sh
 
 
 class FFMpegRecipe(Recipe):
-    version = "2.6.3"
-    url = "http://www.ffmpeg.org/releases/ffmpeg-{version}.tar.bz2"
+    version = "n3.4.5"
+    url = "https://github.com/FFmpeg/FFmpeg/archive/{version}.zip"
     include_per_arch = True
     include_dir = "dist/include"
     optional_depends = ["openssl"]
@@ -17,16 +17,18 @@ class FFMpegRecipe(Recipe):
         "libavresample/libavresample.a",
         "libavutil/libavutil.a",
         "libswresample/libswresample.a",
-        "libswscale/libswscale.a"]
+        "libswscale/libswscale.a",
+    ]
+    pbx_frameworks = ["VideoToolbox"]
 
     def build_arch(self, arch):
         options = [
             "--disable-everything",
-            "--enable-parser=h264,aac",
-            "--enable-decoder=h263,h264,aac",
-            "--enable-filter=aresample,resample,crop",
-            "--enable-protocol=file,http",
-            "--enable-demuxer=sdp",
+            "--enable-parsers",
+            "--enable-decoders",
+            "--enable-demuxers",
+            "--enable-filter=aresample,resample,crop,scale",
+            "--enable-protocol=file,http,rtmp",
             "--enable-pic",
             "--enable-small",
             "--enable-hwaccels",
@@ -41,7 +43,6 @@ class FFMpegRecipe(Recipe):
             "--disable-vdpau",
             "--disable-vaapi",
             "--disable-dct",
-
             # disable binaries / doc
             "--enable-cross-compile",
             "--disable-debug",
@@ -67,6 +68,7 @@ class FFMpegRecipe(Recipe):
                 "--extra-cflags={}".format(build_env["CFLAGS"]),
                 "--extra-cxxflags={}".format(build_env["CFLAGS"]),
                 "--extra-ldflags={}".format(build_env["LDFLAGS"]),
+                "--disable-x86asm",
                 *options,
                 _env=build_env)
         """
@@ -90,4 +92,3 @@ class FFMpegRecipe(Recipe):
 
 
 recipe = FFMpegRecipe()
-

--- a/recipes/ffpyplayer/__init__.py
+++ b/recipes/ffpyplayer/__init__.py
@@ -4,7 +4,7 @@ import sh
 
 
 class FFPyplayerRecipe(CythonRecipe):
-    version = "v3.2"
+    version = "4.2.0"
     url = "https://github.com/matham/ffpyplayer/archive/{version}.zip"
     library = "libffpyplayer.a"
     depends = ["python", "ffmpeg"]
@@ -24,6 +24,13 @@ class FFPyplayerRecipe(CythonRecipe):
             arch.arch, "ffmpeg")
         env["CONFIG_POSTPROC"] = "0"
         return env
+
+    def prebuild_arch(self, arch):
+        # common to all archs
+        if  self.has_marker("patched"):
+            return
+        self.apply_patch("misc-visibility.patch")
+        self.set_marker("patched")
 
 
 recipe = FFPyplayerRecipe()

--- a/recipes/ffpyplayer/misc-visibility.patch
+++ b/recipes/ffpyplayer/misc-visibility.patch
@@ -1,0 +1,41 @@
+diff --git a/ffpyplayer/clib/misc.c b/ffpyplayer/clib/misc.c
+index 55181d1..6011ffa 100644
+--- a/ffpyplayer/clib/misc.c
++++ b/ffpyplayer/clib/misc.c
+@@ -1,8 +1,7 @@
+-
+ #include "misc.h"
+
+ #define FLAGS (o->type == AV_OPT_TYPE_FLAGS) ? AV_DICT_APPEND : 0
+-void print_all_libs_info(int flags, int level)
++void __attribute__ ((visibility ("hidden"))) print_all_libs_info(int flags, int level)
+ {
+ #if CONFIG_AVUTIL
+     PRINT_LIB_INFO(avutil,   AVUTIL,   flags, level);
+@@ -30,7 +29,7 @@ void print_all_libs_info(int flags, int level)
+ #endif
+ }
+
+-const AVOption *opt_find(void *obj, const char *name, const char *unit,
++const AVOption __attribute__ ((visibility ("hidden"))) *opt_find(void *obj, const char *name, const char *unit,
+     int opt_flags, int search_flags)
+ {
+     const AVOption *o = av_opt_find(obj, name, unit, opt_flags, search_flags);
+@@ -40,7 +39,7 @@ const AVOption *opt_find(void *obj, const char *name, const char *unit,
+ }
+
+ #define FLAGS (o->type == AV_OPT_TYPE_FLAGS) ? AV_DICT_APPEND : 0
+-int opt_default(const char *opt, const char *arg,
++int __attribute__ ((visibility ("hidden"))) opt_default(const char *opt, const char *arg,
+     struct SwsContext *sws_opts, AVDictionary **sws_dict, AVDictionary **swr_opts,
+     AVDictionary **resample_opts, AVDictionary **format_opts, AVDictionary **codec_opts)
+ {
+@@ -140,7 +139,7 @@ int opt_default(const char *opt, const char *arg,
+     return AVERROR_OPTION_NOT_FOUND;
+ }
+
+-int get_plane_sizes(int size[4], int required_plane[4], enum AVPixelFormat pix_fmt,
++int __attribute__ ((visibility ("hidden"))) get_plane_sizes(int size[4], int required_plane[4], enum AVPixelFormat pix_fmt,
+     int height, const int linesizes[4])
+ {
+     int i, total_size;


### PR DESCRIPTION
This PR updates the outdated `ffmpeg` and `ffpyplayer` recipes.

Also enables by default all parsers, decoders and demuxers, as We already did in `p4a/ffmpeg` recipe for consistency.

Also supersede the "still-in-wip" PR https://github.com/kivy/kivy-ios/pull/233