### PR TITLE
Add IOS_IS_WINDOWED env switch + update SDL2

### DIFF
--- a/recipes/kivy/__init__.py
+++ b/recipes/kivy/__init__.py
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__)
 
 
 class KivyRecipe(CythonRecipe):
-    # post kivy 1.11.1, including Fbo depthbuffer fixes for iOS
-    version = "18f37ed6e29620ee53c2a7699e0e0894e06a7f91"
+    # post kivy 1.11.1, including statusbar/fullscreen fix
+    version = "38fcbd5b90c99a96d82682f14986836cde81412d"
     url = "https://github.com/kivy/kivy/archive/{version}.zip"
     library = "libkivy.a"
     depends = ["sdl2", "sdl2_image", "sdl2_mixer", "sdl2_ttf", "ios",

--- a/recipes/sdl2/__init__.py
+++ b/recipes/sdl2/__init__.py
@@ -3,10 +3,10 @@ import sh
 
 
 class LibSDL2Recipe(Recipe):
-    version = "2.0.9"
-    url = "https://www.libsdl.org/release/SDL2-{version}.tar.gz"
-    #version = "iOS-improvements"
-    #url = "https://bitbucket.org/slime73/sdl-experiments/get/{version}.tar.gz"
+    # version = "2.0.9"
+    # url = "https://www.libsdl.org/release/SDL2-{version}.tar.gz"
+    version = "7cc4fc886d9e"
+    url = "https://hg.libsdl.org/SDL/archive/{version}.tar.gz"
     library = "Xcode-iOS/SDL/build/Release-{arch.sdk}/libSDL2.a"
     include_dir = "include"
     pbx_frameworks = [

--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -42,6 +42,10 @@ int main(int argc, char *argv[]) {
     putenv("KIVY_IMAGE=imageio,tex,gif");
     putenv("KIVY_AUDIO=sdl2");
     putenv("KIVY_GL_BACKEND=sdl2");
+
+    // IOS_IS_WINDOWED=True disables fullscreen and statusbar is shown
+    putenv("IOS_IS_WINDOWED=False");
+
     #ifndef DEBUG
     putenv("KIVY_NO_CONSOLELOG=1");
     #endif

--- a/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
     putenv("KIVY_AUDIO=sdl2");
     putenv("KIVY_GL_BACKEND=sdl2");
 
-    // IOS_IS_WINDOWED=True disables fullscreen and statusbar is shown
+    // IOS_IS_WINDOWED=True disables fullscreen and then statusbar is shown
     putenv("IOS_IS_WINDOWED=False");
 
     #ifndef DEBUG


### PR DESCRIPTION
These small changes are the last (final) step in order to add the ability to show the statusbar on `iOS`.

- adds `IOS_IS_WINDOWED` env var
- updates SDL2 to a specific post release tag that solves a lot of specific `iOS` issues, and also fixes a focus issue that was preventing from successfully showing the statusbar on `iOS`
- Updates kivy hash in order to include: https://github.com/kivy/kivy/pull/6589