### PR TITLE
[Issue #421] Pillow recipe is broken

### DIFF
--- a/recipes/pillow/__init__.py
+++ b/recipes/pillow/__init__.py
@@ -11,7 +11,7 @@ class PillowRecipe(Recipe):
     library = "libpillow.a"
     depends = ["hostpython3", "host_setuptools3", "freetype", "libjpeg", "python3", "ios"]
     pbx_libraries = ["libz", "libbz2"]
-    include_per_arch = True
+    archs = ['arm64']
 
     def get_pil_env(self, arch):
         build_env = arch.get_env()
@@ -33,7 +33,7 @@ class PillowRecipe(Recipe):
     def build_arch(self, arch):
         build_env = self.get_pil_env(arch)
         hostpython3 = sh.Command(self.ctx.hostpython)
-        shprint(hostpython3, "setup.py", "build_ext", "--disable-tiff",
+        shprint(hostpython3, "setup.py", "build_ext", "--disable-tiff", "--disable-lcms",
             "--disable-webp", "-g", _env=build_env)
         self.biglink()
 

--- a/recipes/pkgresources/pkg_resources.py
+++ b/recipes/pkgresources/pkg_resources.py
@@ -64,7 +64,7 @@ from os.path import isdir, split
 
 # Avoid try/except due to potential problems with delayed import mechanisms.
 if sys.version_info >= (3, 3) and sys.implementation.name == "cpython":
-    import importlib._bootstrap as importlib_bootstrap
+    import importlib._bootstrap_external as importlib_bootstrap
 else:
     importlib_bootstrap = None
 


### PR DESCRIPTION
This disables Little-CMS and allows it to build with out the missing symbols LCMS introduces.  It also sets the arch to arm64.  Before it wasn't building symbols for arm64.