### PR TITLE
Update (and fixes) openssl to 1.1.1f

### DIFF
--- a/recipes/openssl/__init__.py
+++ b/recipes/openssl/__init__.py
@@ -5,43 +5,30 @@ import sh
 
 arch_mapper = {'i386': 'darwin-i386-cc',
                'x86_64': 'darwin64-x86_64-cc',
-               'armv7': 'iphoneos-cross',
-               'arm64': 'iphoneos-cross'}
+               'armv7': 'ios-cross',
+               'arm64': 'ios64-cross'}
 
 
 class OpensslRecipe(Recipe):
-    version = "1.0.2k"
+    version = "1.1.1f"
     url = "http://www.openssl.org/source/openssl-{version}.tar.gz"
     libraries = ["libssl.a", "libcrypto.a"]
     include_dir = "include"
     include_per_arch = True
 
     def build_arch(self, arch):
-        options_iphoneos = (
-            "-isysroot {}".format(arch.sysroot),
-            "-DOPENSSL_THREADS",
-            "-D_REENTRANT",
-            "-DDSO_DLFCN",
-            "-DHAVE_DLFCN_H",
-            "-fomit-frame-pointer",
-            "-fno-common",
-            "-O3"
-        )
         build_env = arch.get_env()
         target = arch_mapper[arch.arch]
         shprint(sh.env, _env=build_env)
         sh.perl(join(self.build_dir, "Configure"),
                 target,
                 _env=build_env)
-        if target == 'iphoneos-cross':
-            sh.sed("-ie", "s!^CFLAG=.*!CFLAG={} {}!".format(build_env['CFLAGS'],
-                   " ".join(options_iphoneos)),
-                   "Makefile")
-            sh.sed("-ie", "s!static volatile sig_atomic_t intr_signal;!static volatile intr_signal;! ",
-                   "crypto/ui/ui_openssl.c")
-        else:
-            sh.sed("-ie", "s!^CFLAG=!CFLAG={} !".format(build_env['CFLAGS']),
-                   "Makefile")
+        if target.endswith('-cross'):
+            with open('Makefile', 'r') as makefile:
+                filedata = makefile.read()
+            filedata = filedata.replace('$(CROSS_TOP)/SDKs/$(CROSS_SDK)', arch.sysroot)
+            with open('Makefile', 'w') as makefile:
+                makefile.write(filedata)
         shprint(sh.make, "clean")
         shprint(sh.make, self.ctx.concurrent_make, "build_libs")
 

--- a/recipes/python3/__init__.py
+++ b/recipes/python3/__init__.py
@@ -139,6 +139,7 @@ class Python3Recipe(Recipe):
         sqlite3_src = join(self.recipe_dir, 'mock_modules', '_sqlite3')
         site_packages_folder = join(
                 self.ctx.dist_dir, "root", "python3", "lib", "python3.7", "site-packages", "_sqlite3")
+        shutil.rmtree(site_packages_folder, ignore_errors=True) # Needed in case of rebuild
         shutil.copytree(sqlite3_src, site_packages_folder)
     
     def reduce_python(self):


### PR DESCRIPTION
**openssl** recipe was broken by a faulty url.
I took the opportunity to update the version to **1.1.1f** (latest stable)

This PR also contains a minor fix needed in case of rebuild of the python3 recipe.

Should fix issues: #437 #434