### PR TITLE
Add python depends

### DIFF
--- a/kivy_ios/recipes/kivy/__init__.py
+++ b/kivy_ios/recipes/kivy/__init__.py
@@ -18,6 +18,7 @@ class KivyRecipe(CythonRecipe):
     library = "libkivy.a"
     depends = ["sdl2", "sdl2_image", "sdl2_mixer", "sdl2_ttf", "ios",
                "pyobjus", "python", "host_setuptools3"]
+    python_depends = ["certifi"]
     pbx_frameworks = ["OpenGLES", "Accelerate", "CoreMedia", "CoreVideo"]
     pre_build_ext = True
 


### PR DESCRIPTION
This PR adds python_depends in recipe.

It's needed, for example, to include `certifi` when building kivy.