### PR TITLE
Continuous Integration minimal build

### DIFF
--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -19,6 +19,26 @@ jobs:
         pip install tox>=2.0
         tox -e pep8
 
+  build_python3_kivy:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout kivy-ios
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7.x
+    - name: Install requirements
+      run: |
+        pip3 install -r requirements.txt
+        pip3 install sh
+        brew install autoconf automake libtool pkg-config
+        brew link libtool
+        pip3 install Cython==0.28.1
+    - name: Build Python & Kivy
+      run: |
+        python toolchain.py build python3 kivy
+
   build_updated_recipes:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
Makes sure at least Python and Kivy are built every time.