### PR TITLE
Do not build known broken recipes

### DIFF
--- a/.ci/constants.py
+++ b/.ci/constants.py
@@ -1,0 +1,19 @@
+BROKEN_RECIPES = set(
+    [
+        # no attribute 'SourceFileLoader'
+        # https://github.com/kivy/kivy-ios/issues/466
+        "distribute",
+        # 'distutils.core' is not a package
+        # https://github.com/kivy/kivy-ios/issues/467
+        "markupsafe",
+        # depends on markupsafe
+        # https://github.com/kivy/kivy-ios/issues/466
+        "jinja2",
+        # bad install directory or PYTHONPATH
+        # https://github.com/kivy/kivy-ios/issues/468
+        "werkzeug",
+    ]
+)
+
+# recipes that were already built will be skipped
+CORE_RECIPES = set(["kivy", "hostpython3", "python3"])

--- a/recipes/distribute/__init__.py
+++ b/recipes/distribute/__init__.py
@@ -6,7 +6,6 @@ import os
 
 class DistributeRecipe(PythonRecipe):
     version = "0.7.3"
-    # url = "https://github.com/mitsuhiko/click/archive/{version}.zip"
     url = "https://pypi.python.org/packages/source/d/distribute/distribute-{version}.zip"
     depends = ["python"]
 


### PR DESCRIPTION
Recipes known to be broken should be part of `BROKEN_RECIPES` and have
a dedicated issue.
Demonstrates with `distribute` recipe that was modified but will be skipped.
Refs: #466, #467 and #468