### PR TITLE
Automatically publish to PyPI upon tagging

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,25 @@
+name: PyPI release
+on: [push]
+
+jobs:
+  pypi_release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade setuptools wheel twine
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+    - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kivy for iOS
 
 [![kivy-ios](https://github.com/kivy/kivy-ios/workflows/kivy-ios/badge.svg)](https://github.com/kivy/kivy-ios/actions?query=workflow%3Akivy-ios)
+[![PyPI version](https://badge.fury.io/py/kivy-ios.svg)](https://badge.fury.io/py/kivy-ios)
 [![Backers on Open Collective](https://opencollective.com/kivy/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/kivy/sponsors/badge.svg)](#sponsors)
 


### PR DESCRIPTION
New `pypi-release.yml` workflow for deploying to PyPI.
The scoped token is already setup in:
https://github.com/kivy/kivy-ios/settings/secrets
Doing a test deployment we got a:
```
Uploading distributions to https://upload.pypi.org/legacy/
Uploading kivy_ios-1.0.0.dev1-py3-none-any.whl

HTTPError: 400 Client Error: File already exists.
See https://pypi.org/help/#file-name-reuse for url:
https://upload.pypi.org/legacy/
```
Which means the credentials are working, refs:
https://github.com/AndreMiras/kivy-ios/runs/644399236