### PR TITLE
Migrates libffi build to Python 3

### DIFF
--- a/.ci/rebuild_updated_recipes.py
+++ b/.ci/rebuild_updated_recipes.py
@@ -26,7 +26,7 @@ def modified_recipes(branch="origin/master"):
     recipes = set()
     for file_path in git_diff:
         if fnmatch(file_path, "kivy_ios/recipes/*/__init__.py\n"):
-            recipe = file_path.split("/")[1]
+            recipe = file_path.split("/")[2]
             recipes.add(recipe)
     return recipes
 

--- a/kivy_ios/recipes/hostlibffi/__init__.py
+++ b/kivy_ios/recipes/hostlibffi/__init__.py
@@ -39,6 +39,7 @@ class LibffiRecipe(Recipe):
         self.apply_patch("staticlib.patch")
         self.apply_patch("staticlib2.patch")
         self.apply_patch("libffi-xcode10.patch")
+        self.apply_patch("generate-darwin-source-and-headers-python3-items.patch")
         self.set_marker("patched")
 
     def build_arch(self, arch):
@@ -48,8 +49,8 @@ class LibffiRecipe(Recipe):
                 "generate-darwin-source-and-headers.py",
                 "_generate-darwin-source-and-headers.py")
             shprint(sh.touch, "generate-darwin-source-and-headers.py")
-        python27 = sh.Command("python2.7")
-        shprint(python27, "_generate-darwin-source-and-headers.py", "--only-osx")
+        python3 = sh.Command("python3")
+        shprint(python3, "_generate-darwin-source-and-headers.py", "--only-osx")
         shprint(sh.xcodebuild,
                 self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",

--- a/kivy_ios/recipes/hostlibffi/generate-darwin-source-and-headers-python3-items.patch
+++ b/kivy_ios/recipes/hostlibffi/generate-darwin-source-and-headers-python3-items.patch
@@ -1,0 +1,12 @@
+diff -Nru libffi-3.2.1/generate-darwin-source-and-headers.py libffi-3.2.1-new/generate-darwin-source-and-headers.py
+--- libffi-3.2.1/generate-darwin-source-and-headers.py	2014-11-08 13:47:24.000000000 +0100
++++ libffi-3.2.1-new/generate-darwin-source-and-headers.py	2020-05-06 10:30:46.000000000 +0200
+@@ -194,7 +194,7 @@
+         build_target(desktop64_platform, platform_headers)
+ 
+     mkdir_p('darwin_common/include')
+-    for header_name, tag_tuples in platform_headers.iteritems():
++    for header_name, tag_tuples in platform_headers.items():
+         basename, suffix = os.path.splitext(header_name)
+         with open(os.path.join('darwin_common/include', header_name), 'w') as header:
+             for tag_tuple in tag_tuples:

--- a/kivy_ios/recipes/libffi/__init__.py
+++ b/kivy_ios/recipes/libffi/__init__.py
@@ -22,6 +22,7 @@ class LibffiRecipe(Recipe):
                 "s/-miphoneos-version-min=5.1.1/-miphoneos-version-min=8.0/g",
                 "generate-darwin-source-and-headers.py")
         self.apply_patch("fix-win32-unreferenced-symbol.patch")
+        self.apply_patch("generate-darwin-source-and-headers-python3-items.patch")
         self.set_marker("patched")
 
     def build_arch(self, arch):
@@ -31,8 +32,8 @@ class LibffiRecipe(Recipe):
                 "generate-darwin-source-and-headers.py",
                 "_generate-darwin-source-and-headers.py")
             shprint(sh.touch, "generate-darwin-source-and-headers.py")
-        python27 = sh.Command("python2.7")
-        shprint(python27, "_generate-darwin-source-and-headers.py", "--only-ios")
+        python3 = sh.Command("python3")
+        shprint(python3, "_generate-darwin-source-and-headers.py", "--only-ios")
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(arch.arch),

--- a/kivy_ios/recipes/libffi/generate-darwin-source-and-headers-python3-items.patch
+++ b/kivy_ios/recipes/libffi/generate-darwin-source-and-headers-python3-items.patch
@@ -1,0 +1,12 @@
+diff -Nru libffi-3.2.1/generate-darwin-source-and-headers.py libffi-3.2.1-new/generate-darwin-source-and-headers.py
+--- libffi-3.2.1/generate-darwin-source-and-headers.py	2014-11-08 13:47:24.000000000 +0100
++++ libffi-3.2.1-new/generate-darwin-source-and-headers.py	2020-05-06 10:30:46.000000000 +0200
+@@ -194,7 +194,7 @@
+         build_target(desktop64_platform, platform_headers)
+ 
+     mkdir_p('darwin_common/include')
+-    for header_name, tag_tuples in platform_headers.iteritems():
++    for header_name, tag_tuples in platform_headers.items():
+         basename, suffix = os.path.splitext(header_name)
+         with open(os.path.join('darwin_common/include', header_name), 'w') as header:
+             for tag_tuple in tag_tuples:


### PR DESCRIPTION
Issue reported libffi upstream:
https://github.com/libffi/libffi/pull/563

Also updates `rebuild_updated_recipes.py` following up #472