### PR TITLE
Uses Python 3 syntax

### DIFF
--- a/kivy_ios/recipes/hostpython3/__init__.py
+++ b/kivy_ios/recipes/hostpython3/__init__.py
@@ -17,7 +17,7 @@ class Hostpython3Recipe(Recipe):
     build_subdir = 'native-build'
 
     def init_with_ctx(self, ctx):
-        super(Hostpython3Recipe, self).init_with_ctx(ctx)
+        super().init_with_ctx(ctx)
         self.set_hostpython(self, "3.8")
         self.ctx.so_suffix = ".cpython-38m-darwin.so"
         self.ctx.hostpython = join(self.ctx.dist_dir, "hostpython3", "bin", "python")

--- a/kivy_ios/recipes/kivy/__init__.py
+++ b/kivy_ios/recipes/kivy/__init__.py
@@ -22,7 +22,7 @@ class KivyRecipe(CythonRecipe):
     pre_build_ext = True
 
     def get_recipe_env(self, arch):
-        env = super(KivyRecipe, self).get_recipe_env(arch)
+        env = super().get_recipe_env(arch)
         env["KIVY_SDL2_PATH"] = ":".join([
             join(self.ctx.dist_dir, "include", "common", "sdl2"),
             join(self.ctx.dist_dir, "include", "common", "sdl2_image"),
@@ -32,7 +32,7 @@ class KivyRecipe(CythonRecipe):
 
     def build_arch(self, arch):
         self._patch_setup()
-        super(KivyRecipe, self).build_arch(arch)
+        super().build_arch(arch)
 
     def _patch_setup(self):
         # patch setup to remove some functionnalities

--- a/kivy_ios/recipes/numpy/__init__.py
+++ b/kivy_ios/recipes/numpy/__init__.py
@@ -21,7 +21,7 @@ class NumpyRecipe(CythonRecipe):
         self.set_marker("patched")
 
     def get_recipe_env(self, arch):
-        env = super(NumpyRecipe, self).get_recipe_env(arch)
+        env = super().get_recipe_env(arch)
         # CC must have the CFLAGS with arm arch, because numpy tries first to
         # compile and execute an empty C to see if the compiler works. This is
         # obviously not working when crosscompiling
@@ -32,7 +32,7 @@ class NumpyRecipe(CythonRecipe):
         return env
 
     def build_arch(self, arch):
-        super(NumpyRecipe, self).build_arch(arch)
+        super().build_arch(arch)
         sh.cp(sh.glob(join(self.build_dir, "build", "temp.*", "libnpy*.a")),
               self.build_dir)
 

--- a/kivy_ios/recipes/python3/__init__.py
+++ b/kivy_ios/recipes/python3/__init__.py
@@ -16,7 +16,7 @@ class Python3Recipe(Recipe):
     pbx_libraries = ["libz", "libbz2", "libsqlite3"]
 
     def init_with_ctx(self, ctx):
-        super(Python3Recipe, self).init_with_ctx(ctx)
+        super().init_with_ctx(ctx)
         self.set_python(self, "3.8")
         ctx.python_ver_dir = "python3.8"
         ctx.python_prefix = join(ctx.dist_dir, "root", "python3")


### PR DESCRIPTION
This is a follow up for #482, uses Python 3 syntax:
- Simplifies `super()` calls
- Removes some unused `super()` (no parent class)
- Removes `object` inheritance
- Drops `IS_PY2` logic
- Drops Python 2 imports