### PR TITLE
:bug: fixes flake8 errors post update

### DIFF
--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -289,7 +289,7 @@ class Graph:
         graph = dict((k, set(v)) for k, v in self.graph.items())
         while graph:
             # Find all items without a parent
-            leftmost = [l for l, s in graph.items() if not s]
+            leftmost = [name for name, dep in graph.items() if not dep]
             if not leftmost:
                 raise ValueError('Dependency cycle detected! %s' % graph)
             # If there is more than one, sort them for predictable order

--- a/kivy_ios/tools/external/xcassets.py
+++ b/kivy_ios/tools/external/xcassets.py
@@ -4,6 +4,7 @@ Icon and LaunchImage generator for iOS
 
 .. author:: Mathieu Virbel <mat@meltingrocks.com>
 """
+# flake8: noqa (E121 mainly)
 
 __all__ = ["launchimage"]
 
@@ -14,7 +15,7 @@ from os.path import join, exists
 from os import makedirs
 
 appicon_json = {
-  "images": [  # noqa: E121
+  "images": [
     {
       "idiom": "iphone",
       "size": "20x20",
@@ -338,7 +339,7 @@ appicon_json = {
 
 
 launchimage_json = {
-  "images": [  # noqa: E121
+  "images": [
     {
       "extent": "full-screen",
       "idiom": "iphone",


### PR DESCRIPTION
The recent `flake8==3.8.1` update reported new errors:
```
kivy_ios/toolchain.py:292:31: E741 ambiguous variable name 'l'
...
```
Also note the entire `xcassets.py` file is being ignored as we can't
seem to use one ignore for the entire list anymore. I'm not sure if
this is a regression or a new feature from flake8.