### PR TITLE
Remove --ignore-installed (reverts #349)

### DIFF
--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1173,7 +1173,7 @@ def _pip(args):
     pip_path = join(ctx.dist_dir, 'hostpython3', 'bin', 'pip3')
 
     if len(args) > 1 and args[0] == "install":
-        pip_args = ["--isolated", "--ignore-installed", "--prefix", ctx.python_prefix]
+        pip_args = ["--isolated", "--prefix", ctx.python_prefix]
         args = ["install"] + pip_args + args[1:]
 
     logger.error("Executing pip with: {}".format(args))


### PR DESCRIPTION
This PR reverts changes introduced in #349

This change it's needed in order to install packages that have dependencies that are previously built package via a recipe. (Ex: kivy_garden packages that have kivy as a dependency)

The `--ignore-installed` flag was probably needed before #443, because We were using the system pip instead of the hostpython one.