### PR TITLE
Move Cython requirement into requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ Additionally you would need few system dependencies and configuration.
       brew install autoconf automake libtool pkg-config
       brew link libtool
 
-- Install Cython (0.29.17):
-
-      # pip method if available (sudo might be needed.)
-      pip3 install Cython==0.29.17
-
-
 ## Using the toolchain
 
 Any Python extensions or C/C++ library must be compiled: you need to have what

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Pillow>=6.1.0
 requests>=2.13
 cookiecutter==1.7.2
 sh==1.12.14
+Cython==0.29.17


### PR DESCRIPTION
As it's just another requirement, it properly belongs in `requirements.txt`?