### PR TITLE
[WIP] Fix/pillow host setuptools3

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can list the available recipes and their versions with:
     numpy        1.16.4
     openssl      1.0.2k
     photolibrary master
-    pillow       6.1.0
+    pillow       7.2.0
     plyer        master
     pycrypto     2.6.1
     pykka        1.2.1

--- a/kivy_ios/recipes/host_setuptools3/__init__.py
+++ b/kivy_ios/recipes/host_setuptools3/__init__.py
@@ -6,7 +6,7 @@ from os.path import join
 class HostSetuptools3(Recipe):
     depends = ["openssl", "hostpython3", "python3"]
     archs = ["x86_64"]
-    version = '40.9.0'
+    version = '49.2.0'
     url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.zip'
 
     @cache_execution

--- a/kivy_ios/recipes/host_setuptools3/__init__.py
+++ b/kivy_ios/recipes/host_setuptools3/__init__.py
@@ -20,5 +20,7 @@ class HostSetuptools3(Recipe):
             # Copy in pkg_resources folder as it's otherwise not found
             sh.cp("-R", "pkg_resources/",
                   join(self.ctx.site_packages_dir, "pkg_resources"))
+            sh.touch(join(self.ctx.site_packages_dir, "pkg_resources",
+                     "py31compat.py"))
 
 recipe = HostSetuptools3()

--- a/kivy_ios/recipes/host_setuptools3/__init__.py
+++ b/kivy_ios/recipes/host_setuptools3/__init__.py
@@ -23,4 +23,5 @@ class HostSetuptools3(Recipe):
             sh.touch(join(self.ctx.site_packages_dir, "pkg_resources",
                      "py31compat.py"))
 
+
 recipe = HostSetuptools3()

--- a/kivy_ios/recipes/host_setuptools3/__init__.py
+++ b/kivy_ios/recipes/host_setuptools3/__init__.py
@@ -1,9 +1,10 @@
 from kivy_ios.toolchain import Recipe, shprint, cd, cache_execution
 import sh
+from os.path import join
 
 
 class HostSetuptools3(Recipe):
-    depends = ["openssl", "hostpython3"]
+    depends = ["openssl", "hostpython3", "python3"]
     archs = ["x86_64"]
     version = '40.9.0'
     url = 'https://pypi.python.org/packages/source/s/setuptools/setuptools-{version}.zip'
@@ -16,5 +17,8 @@ class HostSetuptools3(Recipe):
         with cd(build_dir):
             shprint(hostpython, "setup.py", "install")
 
+            # Copy in pkg_resources folder as it's otherwise not found
+            sh.cp("-R", "pkg_resources/",
+                  join(self.ctx.site_packages_dir, "pkg_resources"))
 
 recipe = HostSetuptools3()

--- a/kivy_ios/recipes/pillow/__init__.py
+++ b/kivy_ios/recipes/pillow/__init__.py
@@ -6,7 +6,7 @@ import fnmatch
 
 
 class PillowRecipe(Recipe):
-    version = "6.1.0"
+    version = "7.2.0"
     url = "https://pypi.python.org/packages/source/P/Pillow/Pillow-{version}.tar.gz"
     library = "libpillow.a"
     depends = ["hostpython3", "host_setuptools3", "freetype", "libjpeg", "python3", "ios"]


### PR DESCRIPTION
This addresses the `pkg_resources` bug via copying the files to the appropriate location as part of the `host_setuptools3`, which manages the setuptools source code. 

closes #529
closes #527

Note: Unless `python3` is installed, the `site_packages_dir` is not set.