### PR TITLE
Add instruction for cleaning cache and the build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ Available commands:
     build         Build a recipe (compile a library for the required target
                     architecture)
     clean         Clean the build of the specified recipe
-    clean_cache   Clean the cache and the build
     distclean     Clean the build and the result
     recipes       List all the available recipes
     status        List all the recipes and their build status

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Available commands:
     build         Build a recipe (compile a library for the required target
                     architecture)
     clean         Clean the build of the specified recipe
+    clean_cache   Clean the cache and the build
     distclean     Clean the build and the result
     recipes       List all the available recipes
     status        List all the recipes and their build status

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1354,6 +1354,14 @@ pip           Install a pip dependency into the distribution
                     print("{recipe.name:<12} {recipe.version:<8}".format(recipe=recipe))
 
     def clean(self):
+        def clean_cache(recipe, ctx):
+            """ Remove download artifacts for this build. """
+            # Remove the cached download
+            recipe_inst = Recipe.get_recipe(recipe, ctx)
+            recipe_inst.ctx = ctx
+            if exists(recipe_inst.archive_fn):
+                shutil.rm(self.archive_fn)
+
         parser = argparse.ArgumentParser(
                 description="Clean the build")
         parser.add_argument("recipe", nargs="*", help="Recipe to clean")
@@ -1365,6 +1373,7 @@ pip           Install a pip dependency into the distribution
                 ctx.state.remove_all("{}.".format(recipe))
                 build_dir = join(ctx.build_dir, recipe)
                 shutil.rmtree(build_dir, ignore_errors=True)
+                clean_cache(recipe, ctx)
         else:
             logger.info("Delete build directory")
             shutil.rmtree(ctx.build_dir, ignore_errors=True)

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1359,7 +1359,7 @@ pip           Install a pip dependency into the distribution
             recipe_inst = Recipe.get_recipe(recipe, ctx)
             recipe_inst.ctx = ctx
             if exists(recipe_inst.archive_fn):
-                shutil.rm(self.archive_fn)
+                unlink(self.archive_fn)
 
         parser = argparse.ArgumentParser(
                 description="Clean the build")

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1356,7 +1356,6 @@ pip           Install a pip dependency into the distribution
     def clean(self):
         def clean_cache(recipe, ctx):
             """ Remove download artifacts for this build. """
-            # Remove the cached download
             recipe_inst = Recipe.get_recipe(recipe, ctx)
             recipe_inst.ctx = ctx
             if exists(recipe_inst.archive_fn):

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1384,11 +1384,6 @@ pip           Install a pip dependency into the distribution
         shutil.rmtree(ctx.dist_dir, ignore_errors=True)
         shutil.rmtree(ctx.cache_dir, ignore_errors=True)
 
-    def clean_cache(self):
-        ctx = Context()
-        shutil.rmtree(ctx.cache_dir, ignore_errors=True)
-        shutil.rmtree(ctx.build_dir, ignore_errors=True)
-
     def status(self):
         ctx = Context()
         for recipe in Recipe.list_recipes():

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1375,6 +1375,11 @@ pip           Install a pip dependency into the distribution
         shutil.rmtree(ctx.dist_dir, ignore_errors=True)
         shutil.rmtree(ctx.cache_dir, ignore_errors=True)
 
+    def clean_cache(self):
+        ctx = Context()
+        shutil.rmtree(ctx.cache_dir, ignore_errors=True)
+        shutil.rmtree(ctx.build_dir, ignore_errors=True)
+
     def status(self):
         ctx = Context()
         for recipe in Recipe.list_recipes():

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1359,7 +1359,7 @@ pip           Install a pip dependency into the distribution
             recipe_inst = Recipe.get_recipe(recipe, ctx)
             recipe_inst.ctx = ctx
             if exists(recipe_inst.archive_fn):
-                unlink(self.archive_fn)
+                unlink(recipe_inst.archive_fn)
 
         parser = argparse.ArgumentParser(
                 description="Clean the build")


### PR DESCRIPTION
References https://github.com/kivy/kivy-ios/issues/352

When cleaning a recipe, the downloaded archive is not removed, and needs to be manually removed from the cache to pick up changes to the recipe source. This is tedious, and clean a recipe would imply removing the cached source as well. This PR does that.