### PR TITLE
WIP: Update openssl and ffmpeg version to fix build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can list the available recipes and their versions with:
     audiostream  master
     click        7.1.2
     cymunk       master
-    ffmpeg       2.6.3
+    ffmpeg       n4.3.1
     ffpyplayer   v3.2
     flask        1.1.2
     freetype     2.5.5
@@ -72,7 +72,7 @@ You can list the available recipes and their versions with:
     markupsafe   1.1.1
     moodstocks   4.1.5
     numpy        1.16.4
-    openssl      1.0.2k
+    openssl      1.1.1g
     photolibrary master
     pillow       6.1.0
     plyer        master

--- a/kivy_ios/recipes/ffmpeg/__init__.py
+++ b/kivy_ios/recipes/ffmpeg/__init__.py
@@ -4,7 +4,7 @@ import sh
 
 
 class FFMpegRecipe(Recipe):
-    version = "n3.4.5"
+    version = "n4.3.1"
     url = "https://github.com/FFmpeg/FFmpeg/archive/{version}.zip"
     include_per_arch = True
     include_dir = "dist/include"

--- a/kivy_ios/recipes/openssl/__init__.py
+++ b/kivy_ios/recipes/openssl/__init__.py
@@ -10,7 +10,7 @@ arch_mapper = {'i386': 'darwin-i386-cc',
 
 
 class OpensslRecipe(Recipe):
-    version = "1.1.1f"
+    version = "1.1.1g"
     url = "http://www.openssl.org/source/openssl-{version}.tar.gz"
     libraries = ["libssl.a", "libcrypto.a"]
     include_dir = "include"


### PR DESCRIPTION
This updates the openssl and ffmpeg recipes, mainly the fix the outdated entry point used by the current ffmpeg recipe.

Relates to this PR: https://github.com/kivy/kivy-ios/issues/552

Informed by this patch: https://www.github.com/kivy/python-for-android/tree/develop/pythonforandroid%2Frecipes%2Fffmpeg%2Fpatches%2Fconfigure.patch