### PR TITLE
Fixes build on Xcode 12.2

### DIFF
--- a/kivy_ios/recipes/hostpython3/__init__.py
+++ b/kivy_ios/recipes/hostpython3/__init__.py
@@ -67,6 +67,8 @@ class Hostpython3Recipe(Recipe):
         os.makedirs(build_subdir, exist_ok=True)
         with cd(build_subdir):
             shprint(configure,
+                    "ac_cv_func_preadv=no",
+                    "ac_cv_func_pwritev=no",
                     "--prefix={}".format(join(self.ctx.dist_dir, "hostpython3")),
                     "--with-openssl={}".format(join(self.ctx.dist_dir, 'hostopenssl')),
                     _env=build_env)


### PR DESCRIPTION
Recently Apple introduced `preadv` and `pwritev` APIs in macOS 11 and iOS 14.
**Xcode 12.2** have these definitions into the SDKs, but due to weak linking, configure will succeed also on macOS < 11
