### PR TITLE
Upgrade hostopenssl to 1.1.1g

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can list the available recipes and their versions with:
     flask        1.1.2
     freetype     2.5.5
     hostlibffi   3.2.1
+    hostopenssl  1.1.1g
     hostpython3  3.7.1
     ios          master
     itsdangerous 1.1.0

--- a/kivy_ios/recipes/hostopenssl/__init__.py
+++ b/kivy_ios/recipes/hostopenssl/__init__.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class HostOpensslRecipe(Recipe):
-    version = "1.1.1f"
+    version = "1.1.1g"
     url = "http://www.openssl.org/source/openssl-{version}.tar.gz"
     archs = ["x86_64"]
 


### PR DESCRIPTION
Build confirmed on Version 11.2.1 (11B53), Mac Cataline
```
Found junk /Users/richard/Repos/kivy/kivy-ios/build/hostopenssl/x86_64/openssl-1.1.1g/demos/certs/apps/mkxcerts.sh, removing
[DEBUG   ] New State: hostopenssl.build.x86_64 at 2020-12-08 15:23:24.954243
[INFO    ] Install include files for hostopenssl
[INFO    ] Install_include hostopenssl
[DEBUG   ] New State: hostopenssl.install_include at 2020-12-08 15:23:24.957459
[INFO    ] Install frameworks for hostopenssl
[INFO    ] Install_frameworks hostopenssl
[DEBUG   ] New State: hostopenssl.install_frameworks at 2020-12-08 15:23:24.959731
[INFO    ] Install sources for hostopenssl
[INFO    ] Install_sources hostopenssl
[DEBUG   ] New State: hostopenssl.install_sources at 2020-12-08 15:23:24.961770
[INFO    ] Install python deps for hostopenssl
[INFO    ] Install_python_deps hostopenssl
[DEBUG   ] New State: hostopenssl.install_python_deps at 2020-12-08 15:23:24.963666
[INFO    ] Install hostopenssl
[DEBUG   ] New State: hostopenssl.build_all at 2020-12-08 15:23:25.087780
```