### PR TITLE
Update kivy to a post 2.0.0 version

### DIFF
--- a/kivy_ios/recipes/kivy/__init__.py
+++ b/kivy_ios/recipes/kivy/__init__.py
@@ -8,12 +8,10 @@ logger = logging.getLogger(__name__)
 
 class KivyRecipe(CythonRecipe):
     """
-    post kivy 2.0.0rc1
-    Includes these iOS specific fixes:
-    - Statusbar / Fullscreen fix (PR #4589)
-    - Extend usage of certifi on iOS (PR #4648)
+    The targeted commit includes these iOS specific fixes that were merged after kivy 2.0.0 release:
+    - Camera: Added API to change avfoundation camera provider orientation (PR #7263)
     """
-    version = "067064c23a275187e67f1c9d7de7cc06f384af4d"
+    version = "b5ec51ed2315a9a890f264b0df6d23c8e6341d42"
     url = "https://github.com/kivy/kivy/archive/{version}.zip"
     library = "libkivy.a"
     depends = ["sdl2", "sdl2_image", "sdl2_mixer", "sdl2_ttf", "ios",


### PR DESCRIPTION
This PR updates kivy recipe to target a post 2.0.0 version that includes a specific iOS improvement.
