### PR TITLE
Fixes Pillow build on Xcode 12.2

### DIFF
--- a/kivy_ios/recipes/pillow/__init__.py
+++ b/kivy_ios/recipes/pillow/__init__.py
@@ -23,7 +23,7 @@ class PillowRecipe(Recipe):
         build_env["ARCH"] = arch.arch
         build_env["C_INCLUDE_PATH"] = join(arch.sysroot, "usr", "include")
         build_env["LIBRARY_PATH"] = join(arch.sysroot, "usr", "lib")
-        build_env["CFLAGS"] = " ".join([
+        build_env["CFLAGS"] += " ".join([
             "-I{}".format(join(self.ctx.dist_dir, "include", arch.arch, "freetype")) +
             " -I{}".format(join(self.ctx.dist_dir, "include", arch.arch, "libjpeg")) +
             " -arch {}".format(arch.arch)


### PR DESCRIPTION
This PR should fix #556 .

That one was broken since a age 😄  , but with XCode < 12.x, also if the needed flags were missing, considering that `-arch arm64`was passed, Xcode considered that as an iOS build. (A bug sometimes it's a feature)

Now, with XCode > 12.x, arm64 is something that exists in MacOS (Apple Silicon M1), so without the needed flags got treated as a MacOS build. 