### PR TITLE
Switch to iOS 9.0 where applicable

### DIFF
--- a/kivy_ios/recipes/hostlibffi/libffi-xcode10.patch
+++ b/kivy_ios/recipes/hostlibffi/libffi-xcode10.patch
@@ -305,7 +305,7 @@
  					darwin_ios/include,
  				);
 -				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
-+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
++				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
  				"IPHONEOS_DEPLOYMENT_TARGET[arch=arm64]" = 7.0;
  				OTHER_LDFLAGS = "-ObjC";
  				PRODUCT_NAME = ffi;

--- a/kivy_ios/recipes/libffi/__init__.py
+++ b/kivy_ios/recipes/libffi/__init__.py
@@ -15,10 +15,9 @@ class LibffiRecipe(Recipe):
     def prebuild_arch(self, arch):
         if self.has_marker("patched"):
             return
-        # XCode 10 minimum is 8.0 now.
         shprint(sh.sed,
                 "-i.bak",
-                "s/-miphoneos-version-min=5.1.1/-miphoneos-version-min=8.0/g",
+                "s/-miphoneos-version-min=5.1.1/-miphoneos-version-min=9.0/g",
                 "generate-darwin-source-and-headers.py")
         self.apply_patch("fix-win32-unreferenced-symbol.patch")
         self.apply_patch("generate-darwin-source-and-headers-python3-items.patch")

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -246,7 +246,7 @@ class Arch64Simulator(Arch):
     sdk = "iphonesimulator"
     arch = "x86_64"
     triple = "x86_64-apple-darwin13"
-    version_min = "-miphoneos-version-min=8.0"
+    version_min = "-miphoneos-version-min=9.0"
     sysroot = sh.xcrun("--sdk", "iphonesimulator", "--show-sdk-path").strip()
 
 
@@ -254,7 +254,7 @@ class Arch64IOS(Arch):
     sdk = "iphoneos"
     arch = "arm64"
     triple = "aarch64-apple-darwin13"
-    version_min = "-miphoneos-version-min=8.0"
+    version_min = "-miphoneos-version-min=9.0"
     sysroot = sh.xcrun("--sdk", "iphoneos", "--show-sdk-path").strip()
 
 

--- a/kivy_ios/tools/liblink
+++ b/kivy_ios/tools/liblink
@@ -83,7 +83,7 @@ if 'arm' in arch:
     min_version_flag = '-ios_version_min'
 else:
     min_version_flag = '-ios_simulator_version_min'
-call = [ld, '-r', '-o', output + '.o', min_version_flag, '8.0', '-arch', arch]
+call = [ld, '-r', '-o', output + '.o', min_version_flag, '9.0', '-arch', arch]
 if min_version_flag == "-ios_version_min":
     call += ["-bitcode_bundle"]
 call += objects

--- a/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/{{ cookiecutter.project_name }}.xcodeproj/project.pbxproj
+++ b/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/{{ cookiecutter.project_name }}.xcodeproj/project.pbxproj
@@ -289,7 +289,7 @@
 					"{{ cookiecutter.dist_dir }}/include/common/sdl2",
 				);
 				INFOPLIST_FILE = "{{ cookiecutter.project_name }}-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"{{ cookiecutter.dist_dir }}/lib",
@@ -326,7 +326,7 @@
 					"{{ cookiecutter.dist_dir }}/include/common/sdl2",
 				);
 				INFOPLIST_FILE = "{{ cookiecutter.project_name }}-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"{{ cookiecutter.dist_dir }}/lib",


### PR DESCRIPTION
For future changes (MetalANGLE + startup storyboard), We should move to 9.0 as a minimum deployment version.

I tried to not increase too much this value, but considering the iOS support matrix, We should be able to increase the minimum version to at least **11.4** without being harmful to old devices.