### PR TITLE
Bump sdl2_ttf to 2.0.15 to improve compatibility with kivymd

### DIFF
--- a/kivy_ios/recipes/sdl2_ttf/__init__.py
+++ b/kivy_ios/recipes/sdl2_ttf/__init__.py
@@ -6,7 +6,7 @@ import shlex
 
 
 class LibSDL2TTFRecipe(Recipe):
-    version = "2.0.14"
+    version = "2.0.15"
     url = "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-{version}.tar.gz"
     library = "libSDL2_ttf.a"
     include_dir = "SDL_ttf.h"


### PR DESCRIPTION
This bugfix update for sdl2_ttf seems to work fine with kivy and allows kivymd icon to display properly. 