### PR TITLE
Fix outdated freetype url

### DIFF
--- a/kivy_ios/recipes/freetype/__init__.py
+++ b/kivy_ios/recipes/freetype/__init__.py
@@ -5,7 +5,7 @@ import sh
 
 class FreetypeRecipe(Recipe):
     version = "2.5.5"
-    url = "http://download.savannah.gnu.org/releases/freetype/freetype-{version}.tar.bz2"
+    url = "https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-{version}.tar.bz2"
     library = "objs/.libs/libfreetype.a"
     include_dir = ["include", ("builds/unix/ftconfig.h", "config/ftconfig.h")]
     include_per_arch = True


### PR DESCRIPTION
This PR fixes issue #629 . Recently freetype moved the old releases into a subfolder.

We should schedule a freetype version update in the near future.