### PR TITLE
Enables buildozer to automatically install dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,21 @@
+[metadata]
+name = kivy-ios
+version = 1.3.0.dev0
+description = Kivy for iOS
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = The Kivy team
+author_email = kivy-dev@googlegroups.com
+url = https://github.com/kivy/kivy-ios
+
+[options]
+python_requires >= "3.6.0"
+install_requires = Cython; cookiecutter; pbxproj; Pillow; requests; sh
+packages = find:
+# note this is a bit excessive as it includes absolutely everything
+# make sure you run with from a clean directory
+include_package_data = True
+
+[options.entry_points]
+console_scripts =
+    toolchain = kivy_ios.toolchain:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = kivy-ios
 version = 1.3.0.dev0
 description = Kivy for iOS
+license = MIT License
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = The Kivy team
@@ -10,7 +11,13 @@ url = https://github.com/kivy/kivy-ios
 
 [options]
 python_requires >= "3.6.0"
-install_requires = Cython; cookiecutter; pbxproj; Pillow; requests; sh
+install_requires =
+    Cython
+    cookiecutter
+    pbxproj
+    Pillow
+    requests
+    sh
 packages = find:
 # note this is a bit excessive as it includes absolutely everything
 # make sure you run with from a clean directory

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,3 @@
-import os
-from glob import glob
-from setuptools import setup, find_packages
+from setuptools import setup
 
-
-def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
-        return f.read()
-
-
-def recursive_include(module):
-    module_path = module.replace(".", "/") + "/"
-    files = glob(f"{module_path}**", recursive=True)
-    return [file.replace(module_path, "") for file in files]
-
-
-setup(
-    name="kivy-ios",
-    version="1.3.0.dev0",
-    description="Kivy for iOS",
-    long_description=read("README.md"),
-    long_description_content_type="text/markdown",
-    author="The Kivy team",
-    author_email="kivy-dev@googlegroups.com",
-    url="https://github.com/kivy/kivy-ios",
-    python_requires=">=3.6.0",
-    install_requires=["cookiecutter", "pbxproj", "Pillow", "requests", "sh"],
-    packages=find_packages(),
-    package_data={
-        # note this method is a bit excessive as it includes absolutely everything
-        # make sure you run with from a clean directory
-        "kivy_ios": recursive_include("kivy_ios"),
-    },
-    entry_points={"console_scripts": ["toolchain = kivy_ios.toolchain:main"]},
-)
+setup()


### PR DESCRIPTION
`setup.cfg` is just an ini file and therefore easy for buildozer to pass and install dependencies.
This will allow `buildozer ios debug|release` to automatically download *and* install kivy-ios dependencies, as it currently does for python-4-android.

[Simple changes](https://github.com/meow464/buildozer/tree/setup_cfg) (compare with master) are also required to the buiuldozer ios target, but this one has to be merged first.

To test this pull request I made [this shell script](https://gist.github.com/meow464/117b1541bb389ee2dd2b86278670c8c8). It uses setup.py to create binary and source distributions on master and on the new branch, then checks if they indeed contain all the same files.