### PR TITLE
CI: Use a Kivy-ios installation for tests, instead of the legacy toolchain.py

### DIFF
--- a/.ci/rebuild_updated_recipes.py
+++ b/.ci/rebuild_updated_recipes.py
@@ -38,7 +38,7 @@ def main():
     updated_recipes = " ".join(recipes)
     if updated_recipes != "":
         subprocess.run(
-            f"python3 toolchain.py build {updated_recipes}", shell=True, check=True
+            f"toolchain build {updated_recipes}", shell=True, check=True
         )
     else:
         print("Nothing to do. No updated recipes.")

--- a/.ci/test_project.sh
+++ b/.ci/test_project.sh
@@ -3,7 +3,7 @@
 
 set -eo pipefail
 
-python3 toolchain.py create Touchtracer kivy-ci-clone/examples/demo/touchtracer
+toolchain create Touchtracer kivy-ci-clone/examples/demo/touchtracer
 
 xcodebuild -project touchtracer-ios/touchtracer.xcodeproj \
             -scheme touchtracer \

--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -35,9 +35,10 @@ jobs:
         brew link libtool
         pip3 install Cython==0.29.17
         gem install xcpretty
+    - name: Install kivy-ios
+      run: python setup.py install
     - name: Build Python & Kivy
-      run: |
-        python toolchain.py build python3 kivy
+      run: toolchain build python3 kivy
     - name: Checkout kivy for tests apps
       uses: actions/checkout@v2
       with:
@@ -65,10 +66,12 @@ jobs:
         brew install autoconf automake libtool pkg-config
         brew link libtool
         pip install Cython==0.29.17
+    - name: Install kivy-ios
+      run: python setup.py install
     - name: Build Python & Kivy
       run: |
         . venv/bin/activate
-        python toolchain.py build python3 kivy
+        toolchain build python3 kivy
     - name: Checkout kivy for tests apps
       uses: actions/checkout@v2
       with:
@@ -95,6 +98,8 @@ jobs:
         brew install autoconf automake libtool pkg-config
         brew link libtool
         pip3 install Cython==0.29.17
+    - name: Install kivy-ios
+      run: python setup.py install
     - name: Build updated recipes
       run: |
         python3 .ci/rebuild_updated_recipes.py


### PR DESCRIPTION
This PR fixes issue #652 .

Tests are expected to fail. (#651 that will be merged after this one should fix them)