### PR TITLE
enable sdl2 image provider to allow image to be saved from widget

### DIFF
--- a/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
+++ b/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/main.m
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
     putenv("KIVY_NO_CONFIG=1");
     putenv("KIVY_NO_FILELOG=1");
     putenv("KIVY_WINDOW=sdl2");
-    putenv("KIVY_IMAGE=imageio,tex,gif");
+    putenv("KIVY_IMAGE=imageio,tex,gif,sdl2");
     putenv("KIVY_AUDIO=sdl2");
     putenv("KIVY_GL_BACKEND=sdl2");
 


### PR DESCRIPTION
Resolves https://github.com/kivy/kivy/issues/7694