### PR TITLE
Bump version to 1.4.0.dev0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = kivy-ios
-version = 1.3.0
+version = 1.4.0.dev0
 description = Kivy for iOS
 license = MIT License
 long_description = file: README.md


### PR DESCRIPTION
Next `kivy-ios` version will be `1.4.0`