### PR TITLE
Fixes libffi 3.4.2 not linking correctly (missing symbols) on iOS Simulator

### DIFF
--- a/kivy_ios/recipes/libffi/__init__.py
+++ b/kivy_ios/recipes/libffi/__init__.py
@@ -15,6 +15,7 @@ class LibffiRecipe(Recipe):
     def prebuild_arch(self, arch):
         if self.has_marker("patched"):
             return
+        self.apply_patch("enable-tramp-build.patch")
         shprint(sh.sed,
                 "-i.bak",
                 "s/-miphoneos-version-min=7.0/-miphoneos-version-min=9.0/g",

--- a/kivy_ios/recipes/libffi/enable-tramp-build.patch
+++ b/kivy_ios/recipes/libffi/enable-tramp-build.patch
@@ -1,0 +1,62 @@
+diff -Naur libffi-3.4.2.orig/libffi.xcodeproj/project.pbxproj libffi-3.4.2/libffi.xcodeproj/project.pbxproj
+--- libffi-3.4.2.orig/libffi.xcodeproj/project.pbxproj	2022-04-03 22:11:12.000000000 +0200
++++ libffi-3.4.2/libffi.xcodeproj/project.pbxproj	2022-04-03 22:17:06.000000000 +0200
+@@ -10,6 +10,10 @@
+ 		43B5D3F81D35473200D1E1FD /* ffiw64_x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = 43B5D3F71D35473200D1E1FD /* ffiw64_x86_64.c */; };
+ 		43B5D3FA1D3547CE00D1E1FD /* win64_x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 43B5D3F91D3547CE00D1E1FD /* win64_x86_64.S */; };
+ 		43E9A5C81D352C1500926A8F /* unix64_x86_64.S in Sources */ = {isa = PBXBuildFile; fileRef = 43E9A5C61D352C1500926A8F /* unix64_x86_64.S */; };
++		AC0D110927FA355D001BCB3D /* tramp.c in Sources */ = {isa = PBXBuildFile; fileRef = AC0D110827FA355D001BCB3D /* tramp.c */; };
++		AC0D110A27FA355D001BCB3D /* tramp.c in Sources */ = {isa = PBXBuildFile; fileRef = AC0D110827FA355D001BCB3D /* tramp.c */; };
++		AC0D110B27FA355D001BCB3D /* tramp.c in Sources */ = {isa = PBXBuildFile; fileRef = AC0D110827FA355D001BCB3D /* tramp.c */; };
++		AC0D110C27FA355D001BCB3D /* tramp.c in Sources */ = {isa = PBXBuildFile; fileRef = AC0D110827FA355D001BCB3D /* tramp.c */; };
+ 		DBFA714A187F1D8600A76262 /* ffi.h in Headers */ = {isa = PBXBuildFile; fileRef = DBFA713E187F1D8600A76262 /* ffi.h */; };
+ 		DBFA714B187F1D8600A76262 /* ffi_common.h in Headers */ = {isa = PBXBuildFile; fileRef = DBFA713F187F1D8600A76262 /* ffi_common.h */; };
+ 		DBFA714C187F1D8600A76262 /* fficonfig.h in Headers */ = {isa = PBXBuildFile; fileRef = DBFA7140187F1D8600A76262 /* fficonfig.h */; };
+@@ -130,6 +134,7 @@
+ 		43E9A5DB1D35374400926A8F /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+ 		43E9A5DC1D35375400926A8F /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+ 		43E9A5DD1D35375400926A8F /* internal64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal64.h; sourceTree = "<group>"; };
++		AC0D110827FA355D001BCB3D /* tramp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tramp.c; path = src/tramp.c; sourceTree = SOURCE_ROOT; };
+ 		DB13B1661849DF1E0010F42D /* libffi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libffi.a; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		DB13B1911849DF510010F42D /* ffi.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = ffi.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		DBFA713E187F1D8600A76262 /* ffi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ffi.h; sourceTree = "<group>"; };
+@@ -214,6 +219,7 @@
+ 		DBFA7142187F1D8600A76262 /* src */ = {
+ 			isa = PBXGroup;
+ 			children = (
++				AC0D110827FA355D001BCB3D /* tramp.c */,
+ 				DBFA7143187F1D8600A76262 /* closures.c */,
+ 				DBFA7145187F1D8600A76262 /* dlmalloc.c */,
+ 				DBFA7147187F1D8600A76262 /* prep_cif.c */,
+@@ -513,6 +519,7 @@
+ 				43E9A5C81D352C1500926A8F /* unix64_x86_64.S in Sources */,
+ 				DBFA717E187F1D9B00A76262 /* ffi64_x86_64.c in Sources */,
+ 				DBFA7179187F1D9B00A76262 /* ffi_armv7.c in Sources */,
++				AC0D110927FA355D001BCB3D /* tramp.c in Sources */,
+ 				DBFA714E187F1D8600A76262 /* closures.c in Sources */,
+ 				DBFA717A187F1D9B00A76262 /* sysv_armv7.S in Sources */,
+ 				43B5D3F81D35473200D1E1FD /* ffiw64_x86_64.c in Sources */,
+@@ -535,6 +542,7 @@
+ 				DBFA715B187F1D8600A76262 /* types.c in Sources */,
+ 				DBFA7159187F1D8600A76262 /* raw_api.c in Sources */,
+ 				DBFA714F187F1D8600A76262 /* closures.c in Sources */,
++				AC0D110B27FA355D001BCB3D /* tramp.c in Sources */,
+ 				DBFA7194187F1DA100A76262 /* unix64_x86_64.S in Sources */,
+ 				FDDB2F461F5D691E00EF414E /* win64_x86_64.S in Sources */,
+ 			);
+@@ -547,6 +555,7 @@
+ 				FDB52FB31F6144FA00AA92E6 /* unix64_x86_64.S in Sources */,
+ 				FDB52FB51F6144FA00AA92E6 /* ffi64_x86_64.c in Sources */,
+ 				FDB52FB61F6144FA00AA92E6 /* ffi_armv7.c in Sources */,
++				AC0D110A27FA355D001BCB3D /* tramp.c in Sources */,
+ 				FDB52FB71F6144FA00AA92E6 /* closures.c in Sources */,
+ 				FDB52FB81F6144FA00AA92E6 /* sysv_armv7.S in Sources */,
+ 				FDB52FB91F6144FA00AA92E6 /* ffiw64_x86_64.c in Sources */,
+@@ -569,6 +578,7 @@
+ 				FDDB2F4F1F5D846400EF414E /* types.c in Sources */,
+ 				FDDB2F501F5D846400EF414E /* raw_api.c in Sources */,
+ 				FDDB2F511F5D846400EF414E /* closures.c in Sources */,
++				AC0D110C27FA355D001BCB3D /* tramp.c in Sources */,
+ 				FDDB2F521F5D846400EF414E /* unix64_x86_64.S in Sources */,
+ 				FDDB2F531F5D846400EF414E /* win64_x86_64.S in Sources */,
+ 			);


### PR DESCRIPTION
`libffi` is not exposing (may be due to a `libffi` bug, have to dig into it a little deeper) `ffi_tramp_alloc`, `ffi_tramp_free`, `ffi_tramp_get_addr`, `ffi_tramp_is_supported`.

Fixes issue #694 