### PR TITLE
Added the ability to pass arguments to as a string

### DIFF
--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1364,8 +1364,9 @@ pip           Install a pip dependency into the distribution
             logger.info("Using pigz to decompress gzip data")
         if ctx.use_pbzip2:
             logger.info("Using pbzip2 to decompress bzip2 data")
-
-        build_recipes(args.recipe, ctx)
+            
+        recipe = ''.join(args.recipe).split()
+        build_recipes(recipe, ctx)
 
     def recipes(self):
         parser = argparse.ArgumentParser(

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1365,7 +1365,7 @@ pip           Install a pip dependency into the distribution
         if ctx.use_pbzip2:
             logger.info("Using pbzip2 to decompress bzip2 data")
 
-        recipe = ''.join(args.recipe).replace(',', '').replace('  ', ' ').split()
+        recipe = ' '.join(args.recipe).replace(',', '').replace('  ', ' ').split()
         build_recipes(recipe, ctx)
 
     def recipes(self):

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -7,7 +7,6 @@ This tool intend to replace all the previous tools/ in shell script.
 """
 
 import argparse
-import os.path
 import platform
 import sys
 from sys import stdout

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1364,8 +1364,8 @@ pip           Install a pip dependency into the distribution
             logger.info("Using pigz to decompress gzip data")
         if ctx.use_pbzip2:
             logger.info("Using pbzip2 to decompress bzip2 data")
-            
-        recipe = ''.join(args.recipe).split()
+
+        recipe = ''.join(args.recipe).replace(',', '').split()
         build_recipes(recipe, ctx)
 
     def recipes(self):

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1512,7 +1512,8 @@ pip           Install a pip dependency into the distribution
         self.pip()
 
     def pip(self):
-        _pip(sys.argv[2:])
+        args = ' '.join(sys.argv[2:]).replace(',', '').replace(' ', ' ').split()
+        _pip(args)
 
     def launchimage(self):
         from .tools.external import xcassets

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1365,7 +1365,7 @@ pip           Install a pip dependency into the distribution
         if ctx.use_pbzip2:
             logger.info("Using pbzip2 to decompress bzip2 data")
 
-        recipe = ''.join(args.recipe).replace(',', '').split()
+        recipe = ''.join(args.recipe).replace(',', '').replace('  ', ' ').split()
         build_recipes(recipe, ctx)
 
     def recipes(self):


### PR DESCRIPTION
Previously, if you read dependencies from a file and passed `"$requirements"` from toolchain build, then the script accepted dependencies with one line (`['kivy python3']`), now this is fixed

### Example:
we have file _requirements.txt_ with (**python3, kivy, openssl  pillow**)
although we have double spaces and commas in the file, the libraries are read and assembled correctly

```bash
requirements="$(cat requirements.txt)"
toolchain build "$requirements"
toolchain pip install ecdsa, bcrypt, cryptography
```

```py
req = 'python3 kivy, openssl   pillow'
recipe = ''.join(req).replace(',', '').replace('  ', ' ').split()
print(recipe)  # ['python3', 'kivy', 'openssl', 'pillow']
```
[test_req.txt](https://github.com/kivy/kivy-ios/files/9126357/test_req.txt)

