### PR TITLE
Added `kivymd` recipe

### DIFF
--- a/kivy_ios/recipes/kivymd/__init__.py
+++ b/kivy_ios/recipes/kivymd/__init__.py
@@ -1,0 +1,10 @@
+from kivy_ios.toolchain import PythonRecipe
+
+
+class KivyMDRecipe(PythonRecipe):
+    version = "master"
+    url = f"https://github.com/Neizvestnyj/KivyMD/archive/{version}.zip"
+    depends = ["python", "kivy", "pillow"]
+
+
+recipe = KivyMDRecipe()


### PR DESCRIPTION
I added a recipe for `kivymd`, but during the test build I get an error. For some reason, the `.kv` files were not added to the **root/lib/site-packages/kivymd** folder. Is it related to the library itself and is my recipe correct?
**Work fine if I use**:
```bash
toolchain build python3 kivy pillow
toolchain pip install https://github.com/kivymd/KivyMD/archive/master.zip
```
Got dlopen error on Foundation: dlopen(/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation, 0x0001): tried: '/Users/neizvestnyj/Library/Developer/Xcode/DerivedData/test-ayrowqcxwpoomwbqlsurwrjgejyp/Build/Products/Debug-iphonesimulator/Foundation.framework/Versions/Current/Foundation' (no such file), '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation' (no such file), '/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation' (no such file), '/Users/neizvestnyj/Library/Developer/Xcode/DerivedData/test-ayrowqcxwpoomwbqlsurwrjgejyp/Build/Products/Debug-iphonesimulator/Foundation.framework/Versions/C/Foundation' (no such file), '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation' (no such file), '/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation' (no such file)
Got fallback dlopen error on Foundation: dlopen(/Groups/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation, 0x0001): tried: '/Users/neizvestnyj/Library/Developer/Xcode/DerivedData/test-ayrowqcxwpoomwbqlsurwrjgejyp/Build/Products/Debug-iphonesimulator/Foundation.framework/Versions/Current/Foundation' (no such file), '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Groups/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation' (no such file), '/Groups/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation' (no such file), '/System/Library/Frameworks/Foundation.framework/Versions/Current/Foundation' (no such file)
 Traceback (most recent call last):
   File "/Users/neizvestnyj/PycharmProjects/StyleTransfer/ios/test-ios/YourApp/main.py", line 4, in <module>
   File "/Users/neizvestnyj/Library/Developer/CoreSimulator/Devices/88558936-C87E-4DF7-AC85-B9EAB3D5FC23/data/Containers/Bundle/Application/E5C06297-C6A4-4AD4-8986-ACF1FB2F0A66/test.app/lib/python3.9/site-packages/kivymd/uix/button/__init__.py", line 2, in <module>
     from .button import (
   File "/Users/neizvestnyj/Library/Developer/CoreSimulator/Devices/88558936-C87E-4DF7-AC85-B9EAB3D5FC23/data/Containers/Bundle/Application/E5C06297-C6A4-4AD4-8986-ACF1FB2F0A66/test.app/lib/python3.9/site-packages/kivymd/uix/button/button.py", line 517, in <module>
     from kivymd.uix.label import MDLabel
   File "/Users/neizvestnyj/Library/Developer/CoreSimulator/Devices/88558936-C87E-4DF7-AC85-B9EAB3D5FC23/data/Containers/Bundle/Application/E5C06297-C6A4-4AD4-8986-ACF1FB2F0A66/test.app/lib/python3.9/site-packages/kivymd/uix/label/__init__.py", line 1, in <module>
     from .label import MDIcon, MDLabel  # NOQA F401
   File "/Users/neizvestnyj/Library/Developer/CoreSimulator/Devices/88558936-C87E-4DF7-AC85-B9EAB3D5FC23/data/Containers/Bundle/Application/E5C06297-C6A4-4AD4-8986-ACF1FB2F0A66/test.app/lib/python3.9/site-packages/kivymd/uix/label/label.py", line 256, in <module>
     with open(
 FileNotFoundError: [Errno 2] No such file or directory: '/Users/neizvestnyj/Library/Developer/CoreSimulator/Devices/88558936-C87E-4DF7-AC85-B9EAB3D5FC23/data/Containers/Bundle/Application/E5C06297-C6A4-4AD4-8986-ACF1FB2F0A66/test.app/lib/python3.9/site-packages/kivymd/uix/label/label.kv'
 ```