### PR TITLE
Use `shutil.which` instead of `sh.which`

### DIFF
--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -184,7 +184,7 @@ class Arch:
         use_ccache = environ.get("USE_CCACHE", "1")
         ccache = None
         if use_ccache == "1":
-            ccache = sh.which('ccache')
+            ccache = shutil.which('ccache')
         if ccache:
             ccache = ccache.strip()
             env["USE_CCACHE"] = "1"
@@ -361,9 +361,9 @@ class Context:
             Arch64IOS(self))
 
         # path to some tools
-        self.ccache = sh.which("ccache")
+        self.ccache = shutil.which("ccache")
         for cython_fn in ("cython-2.7", "cython"):
-            cython = sh.which(cython_fn)
+            cython = shutil.which(cython_fn)
             if cython:
                 self.cython = cython
                 break
@@ -373,15 +373,15 @@ class Context:
 
         # check the basic tools
         for tool in ("pkg-config", "autoconf", "automake", "libtool"):
-            if not sh.which(tool):
+            if not shutil.which(tool):
                 logger.error("Missing requirement: {} is not installed".format(
                     tool))
 
         if not ok:
             sys.exit(1)
 
-        self.use_pigz = sh.which('pigz')
-        self.use_pbzip2 = sh.which('pbzip2')
+        self.use_pigz = shutil.which('pigz')
+        self.use_pbzip2 = shutil.which('pbzip2')
 
         try:
             num_cores = int(sh.sysctl('-n', 'hw.ncpu'))


### PR DESCRIPTION
- Recently our CI started to fail when checking the availability of certain tools (E.g. `ccache` ...)
See: https://github.com/kivy/kivy-ios/runs/7413749298
- `sh` released a new version (1.14.3, 12 hours ago) with a breaking change on our side.
- This is due to https://github.com/amoffat/sh/pull/584
- They are right, and in order to achieve what we expect `shutil.which("name")` should be used instead, as returns `None` when a cmd is not found.

  From [Python](https://docs.python.org/3/library/shutil.html#shutil.which) docs:
  > Return the path to an executable which would be run if the given cmd was called. If no cmd would be called, return None.