### PR TITLE
Use `sys.executable` instead of `sh.python`

### DIFF
--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -1056,7 +1056,7 @@ class CythonRecipe(PythonRecipe):
         # doesn't (yet) have the executable bit hence we explicitly call it
         # with the Python interpreter
         cythonize_script = join(self.ctx.root_dir, "tools", "cythonize.py")
-        shprint(sh.python, cythonize_script, filename)
+        shprint(sh.Command(sys.executable), cythonize_script, filename)
 
     def cythonize_build(self):
         if not self.cythonize:


### PR DESCRIPTION
Fixes the following error:
```
File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/kivy_ios/toolchain.py", line 1059, in cythonize_file
    shprint(sh.python, cythonize_script, filename)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/sh.py", line 3548, in getattr
    return self.env[name]
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/sh.py", line 3330, in getitem__
    raise CommandNotFound(k)
sh.CommandNotFound: python
```

- Latest macOS Monterey does not have `python` (Python 2), but only `python3`
- We should make sure that the Python executable which is calling the `cythonize.py` script is the same of the one used to run the toolchain.

