### PR TITLE
Fixes some E275 - assert is a keyword

### DIFF
--- a/kivy_ios/tools/cythonize.py
+++ b/kivy_ios/tools/cythonize.py
@@ -21,7 +21,7 @@ def resolve_cython():
 
 def do(fn):
     print('cythonize:', fn)
-    assert(fn.endswith('.pyx'))
+    assert fn.endswith('.pyx')
     parts = fn.split('/')
     if parts[0] == '.':
         parts.pop(0)


### PR DESCRIPTION
- Assert is a keyword and a space is needed + the parentheses are not needed.
- A recent change in pycodestyle (See: https://github.com/PyCQA/pycodestyle/pull/1063) introduced this check.
- CI runs started to fail recently