### PR TITLE
Update SDL2, SDL2_ttf, SDL2_mixer, SDL2_image to latest releases

### DIFF
--- a/kivy_ios/recipes/sdl2/__init__.py
+++ b/kivy_ios/recipes/sdl2/__init__.py
@@ -3,16 +3,14 @@ import sh
 
 
 class LibSDL2Recipe(Recipe):
-    # version = "2.0.9"
-    # url = "https://www.libsdl.org/release/SDL2-{version}.tar.gz"
-    version = "7cc4fc886d9e"
-    url = "https://hg.libsdl.org/SDL/archive/{version}.tar.gz"
-    library = "Xcode-iOS/SDL/build/Release-{arch.sdk}/libSDL2.a"
+    version = "2.24.1"
+    url = "https://github.com/libsdl-org/SDL/releases/download/release-{version}/SDL2-{version}.tar.gz"
+    library = "Xcode/SDL/build/Release-{arch.sdk}/libSDL2.a"
     include_dir = "include"
     pbx_frameworks = [
         "OpenGLES", "AudioToolbox", "QuartzCore", "CoreGraphics",
         "CoreMotion", "GameController", "AVFoundation", "Metal",
-        "UIKit"]
+        "UIKit", "CoreHaptics", "CoreBluetooth"]
 
     def prebuild_arch(self, arch):
         if self.has_marker("patched"):
@@ -28,8 +26,8 @@ class LibSDL2Recipe(Recipe):
                 "BITCODE_GENERATION_MODE=bitcode",
                 "CC={}".format(env['CC']),
                 "-sdk", arch.sdk,
-                "-project", "Xcode-iOS/SDL/SDL.xcodeproj",
-                "-target", "libSDL-iOS",
+                "-project", "Xcode/SDL/SDL.xcodeproj",
+                "-target", "Static Library-iOS",
                 "-configuration", "Release")
 
 

--- a/kivy_ios/recipes/sdl2_image/__init__.py
+++ b/kivy_ios/recipes/sdl2_image/__init__.py
@@ -4,12 +4,21 @@ import sh
 
 
 class LibSDL2ImageRecipe(Recipe):
-    version = "2.0.4"
-    url = "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-{version}.tar.gz"
-    library = "Xcode-iOS/build/Release-{arch.sdk}/libSDL2_image.a"
+    version = "2.6.2"
+    url = "https://github.com/libsdl-org/SDL_image/releases/download/release-{version}/SDL2_image-{version}.tar.gz"
+    library = "Xcode/build/Release-{arch.sdk}/libSDL2_image.a"
     include_dir = "SDL_image.h"
     depends = ["sdl2"]
     pbx_frameworks = ["CoreGraphics", "MobileCoreServices"]
+
+    def prebuild_arch(self, arch):
+        if self.has_marker("patched"):
+            return
+        # fix-ios-xcodebuild is a patch taken from the SDL2_image repo
+        # (See: https://github.com/libsdl-org/SDL_image/pull/292)
+        # We will need to remove it once is included into a release
+        self.apply_patch("fix-ios-xcodebuild.patch")
+        self.set_marker("patched")
 
     def build_arch(self, arch):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
@@ -19,8 +28,8 @@ class LibSDL2ImageRecipe(Recipe):
                 "HEADER_SEARCH_PATHS={}".format(
                     join(self.ctx.include_dir, "common", "sdl2")),
                 "-sdk", arch.sdk,
-                "-project", "Xcode-iOS/SDL_image.xcodeproj",
-                "-target", "libSDL_image-iOS",
+                "-project", "Xcode/SDL_image.xcodeproj",
+                "-target", "Static Library",
                 "-configuration", "Release")
 
 

--- a/kivy_ios/recipes/sdl2_image/fix-ios-xcodebuild.patch
+++ b/kivy_ios/recipes/sdl2_image/fix-ios-xcodebuild.patch
@@ -1,0 +1,13 @@
+diff --git a/Xcode/SDL_image.xcodeproj/project.pbxproj b/Xcode/SDL_image.xcodeproj/project.pbxproj
+index a64c8665..69565703 100644
+--- a/Xcode/SDL_image.xcodeproj/project.pbxproj
++++ b/Xcode/SDL_image.xcodeproj/project.pbxproj
+@@ -7,7 +7,7 @@
+ 	objects = {
+ 
+ /* Begin PBXBuildFile section */
+-		007288A80F0DA79800C302A9 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 007288A60F0DA79800C302A9 /* ApplicationServices.framework */; };
++		007288A80F0DA79800C302A9 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 007288A60F0DA79800C302A9 /* ApplicationServices.framework */; platformFilters = (macos, ); };
+ 		6313BF532785566D00F268AD /* IMG_qoi.c in Sources */ = {isa = PBXBuildFile; fileRef = 6313BF522785566D00F268AD /* IMG_qoi.c */; };
+ 		6313BF542785566D00F268AD /* IMG_qoi.c in Sources */ = {isa = PBXBuildFile; fileRef = 6313BF522785566D00F268AD /* IMG_qoi.c */; };
+ 		AA23FC7D20A2A1B90017DFB9 /* IMG_svg.c in Sources */ = {isa = PBXBuildFile; fileRef = AA50AA461F9C7C50003B9C0C /* IMG_svg.c */; };

--- a/kivy_ios/recipes/sdl2_mixer/__init__.py
+++ b/kivy_ios/recipes/sdl2_mixer/__init__.py
@@ -3,10 +3,10 @@ import sh
 
 
 class LibSDL2MixerRecipe(Recipe):
-    version = "2.0.4"
-    url = "http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-{version}.tar.gz"
-    library = "Xcode-iOS/build/Release-{arch.sdk}/libSDL2_mixer.a"
-    include_dir = "SDL_mixer.h"
+    version = "2.6.2"
+    url = "https://github.com/libsdl-org/SDL_mixer/releases/download/release-{version}/SDL2_mixer-{version}.tar.gz"
+    library = "Xcode/build/Release-{arch.sdk}/libSDL2_mixer.a"
+    include_dir = "include/SDL_mixer.h"
     depends = ["sdl2"]
     pbx_frameworks = ["ImageIO"]
     pbx_libraries = ["libc++"]
@@ -21,8 +21,8 @@ class LibSDL2MixerRecipe(Recipe):
                 "BITCODE_GENERATION_MODE=bitcode",
                 "HEADER_SEARCH_PATHS=$HEADER_SEARCH_PATHS /usr/include/machine {} ".format(" ".join(arch.include_dirs)),
                 "-sdk", arch.sdk,
-                "-project", "Xcode-iOS/SDL_mixer.xcodeproj",
-                "-target", "libSDL_mixer-iOS",
+                "-project", "Xcode/SDL_mixer.xcodeproj",
+                "-target", "Static Library",
                 "-configuration", "Release")
 
 

--- a/kivy_ios/recipes/sdl2_ttf/__init__.py
+++ b/kivy_ios/recipes/sdl2_ttf/__init__.py
@@ -1,34 +1,26 @@
 from kivy_ios.toolchain import Recipe, shprint
 from os.path import join
 import sh
-import shutil
-import shlex
 
 
 class LibSDL2TTFRecipe(Recipe):
-    version = "2.0.15"
-    url = "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-{version}.tar.gz"
-    library = "libSDL2_ttf.a"
+    version = "2.20.1"
+    url = "https://github.com/libsdl-org/SDL_ttf/releases/download/release-{version}/SDL2_ttf-{version}.tar.gz"
+    library = "Xcode/build/Release-{arch.sdk}/libSDL2_ttf.a"
     include_dir = "SDL_ttf.h"
-    depends = ["sdl2", "freetype"]
+    depends = ["sdl2"]
 
     def build_arch(self, arch):
-        # XCode-iOS have shipped freetype that don't work with i386
-        # ./configure require too much things to setup it correcly.
-        # so build by hand.
-        build_env = arch.get_env()
-        cc = sh.Command(build_env["CC"])
-        output = join(self.build_dir, "SDL_ttf.o")
-        args = shlex.split(build_env["CFLAGS"])
-        args += ["-c", "-o", output, "SDL_ttf.c"]
-        shprint(cc, *args)
-        shprint(sh.ar, "-q", join(self.build_dir, "libSDL2_ttf.a"), output)
-
-    def install(self):
-        for arch in self.filtered_archs:
-            shutil.copy(
-                join(self.get_build_dir(arch.arch), "SDL_ttf.h"),
-                join(self.ctx.include_dir, "common", "SDL2"))
+        shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
+                "ONLY_ACTIVE_ARCH=NO",
+                "ARCHS={}".format(arch.arch),
+                "BITCODE_GENERATION_MODE=bitcode",
+                "HEADER_SEARCH_PATHS={}".format(
+                    join(self.ctx.include_dir, "common", "sdl2")),
+                "-sdk", arch.sdk,
+                "-project", "Xcode/SDL_ttf.xcodeproj",
+                "-target", "Static Library",
+                "-configuration", "Release")
 
 
 recipe = LibSDL2TTFRecipe()


### PR DESCRIPTION
✅ Tested on runtime @ `iPhone 12 Pro + iOS 16.0.2`
💡  `SDL2_ttf` now self-builds (and statically links to) `libfreetype` and `harfbuzz`.
💡 Now `SDL2_image` supports `webp` out of the box, so #715 is not needed anymore (@tito that works for your use-case?).
💡 `CoreHaptics` and `CoreBluetooth` are now a link-time requirement by sdl2.
💡 `fix-ios-xcodebuild.patch` on `SDL2_image` (taken from SDL_image main branch) allow to build on Xcode < 14 (Xcode doesn't treat it as an error, and automagically applies the filter)

**SDL2**: `2.0.9` --> `2.24.1`
**SDL2_image**: `2.0.4` --> `2.6.2`
**SDL2_mixer**: `2.0.4` --> `2.6.2`
**SDL2_ttf**: `2.0.15` --> `2.20.1`