### PR TITLE
Flake8 does not support inline comments for any of the keys

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,13 @@ commands = flake8 kivy_ios/ tests/ .ci/ setup.py toolchain.py
 
 [flake8]
 ignore =
-    E123,  # Closing bracket does not match indentation of opening bracket's line
-    E126,  # Continuation line over-indented for hanging indent
-    E501,  # Line too long (82 > 79 characters)
-    W503,  # Line break occurred before a binary operator
-    W504   # Line break occurred after a binary operator
+    # Closing bracket does not match indentation of opening bracket's line
+    E123,
+    # Continuation line over-indented for hanging indent
+    E126,
+    # Line too long (82 > 79 characters)
+    E501,
+    # Line break occurred before a binary operator
+    W503,
+    # Line break occurred after a binary operator
+    W504


### PR DESCRIPTION
See:
- https://github.com/PyCQA/flake8/issues/1760

From https://flake8.pycqa.org/en/latest/user/configuration.html :
> Following the recommended settings for [Python’s configparser](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour), Flake8 does not support inline comments for any of the keys. So while this is fine:
```
[flake8]
per-file-ignores =
    # imported but unused
    __init__.py: F401
```
> this is not:
```
[flake8]
per-file-ignores =
    __init__.py: F401 # imported but unused
```

Same of https://github.com/kivy/python-for-android/pull/2708