### PR TITLE
Update pbxproj pinned version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pbxproj==2.5.1
+pbxproj==3.5.0
 Pillow>=6.1.0
 requests>=2.13
 cookiecutter==2.1.1


### PR DESCRIPTION
The CI (and locally, when dependencies are installed via `requirements.txt`) is failing to process the install of `pbxproj==2.5.1` (looks related to an incompatibility with the new `setuptools` and `pbxproj==2.5.1` is very old).

`pbxproj==3.5.0` just works fine 😄 



