### PR TITLE
Disable configuration of `i386-Simulator` for `libffi`

### DIFF
--- a/kivy_ios/recipes/libffi/__init__.py
+++ b/kivy_ios/recipes/libffi/__init__.py
@@ -20,6 +20,10 @@ class LibffiRecipe(Recipe):
                 "-i.bak",
                 "s/-miphoneos-version-min=7.0/-miphoneos-version-min=9.0/g",
                 "generate-darwin-source-and-headers.py")
+        shprint(sh.sed,
+                "-i.bak",
+                "s/build_target(ios_simulator_platform, platform_headers)/print('Skipping i386')/g",
+                "generate-darwin-source-and-headers.py")
         self.set_marker("patched")
 
     def build_arch(self, arch):


### PR DESCRIPTION
CI runs on `macos-latest` runners ( macOS Monterey ) get stuck at `checking for suffix of executables...` while `configure` is running for `i386-apple-darwin11-gcc` host.

This is happening also outside of `kivy-ios`.

Since we don't need that configuration, skipping it allows us to complete the build.

I was not able to reproduce the same issue on macOS Monterey + Apple Silicon. (Everything works flawlessly)