### PR TITLE
Update required Xcode version to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install [Kivy for iOS from PyPI](https://pypi.org/project/kivy-ios) with pip lik
 
 Additionally, you would need a few system dependencies and configuration.
 
-- Xcode 10 or above, with an iOS SDK and command line tools installed:
+- Xcode 13 or above, with an iOS SDK and command line tools installed:
 
       xcode-select --install
 


### PR DESCRIPTION
 SDL XCode projects only support XCode >= 13 , as projects have been migrated to multi-platform support.
 
 Additonally, XCode < 13 is also unsupported by Apple: [App Store submission requirement starts April 25](https://developer.apple.com/news/?id=2t1chhp3)
 
 Closes: #763 