### PR TITLE
Upgrade more GitHub Actions plus Python 3.11.1 and Cython 0.29.33

### DIFF
--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
     - name: Checkout kivy-ios
       uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: 3.x
     - name: Run flake8
       run: |
         python -m pip install --upgrade pip
@@ -25,9 +25,9 @@ jobs:
       matrix:
         include:
           - runs_on: macos-latest
-            python: '3.10'
+            python: 3.x
           - runs_on: apple-silicon-m1
-            python: '3.10.7'
+            python: '3.11'
     steps:
     - name: Checkout kivy-ios
       uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
         pip3 install -r requirements.txt
         brew install autoconf automake libtool pkg-config
         brew link libtool
-        pip3 install Cython==0.29.17
+        pip3 install Cython==0.29.33
         sudo gem install xcpretty
     - name: Install kivy-ios
       run: |
@@ -75,9 +75,9 @@ jobs:
       matrix:
         include:
           - runs_on: macos-latest
-            python: '3.10'
+            python: 3.x
           - runs_on: apple-silicon-m1
-            python: '3.10.7'
+            python: '3.11'
     steps:
     - name: Checkout kivy-ios
       uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         pip install sh
         brew install autoconf automake libtool pkg-config
         brew link libtool
-        pip install Cython==0.29.17
+        pip install Cython==0.29.33
         sudo gem install xcpretty
     - name: Install kivy-ios
       run: |
@@ -131,9 +131,9 @@ jobs:
       matrix:
         include:
           - runs_on: macos-latest
-            python: '3.10'
+            python: 3.x
           - runs_on: apple-silicon-m1
-            python: '3.10.7'
+            python: '3.11'
     steps:
     - name: Checkout kivy-ios
       uses: actions/checkout@v3
@@ -152,7 +152,7 @@ jobs:
         pip3 install -r requirements.txt
         brew install autoconf automake libtool pkg-config
         brew link libtool
-        pip3 install Cython==0.29.17
+        pip3 install Cython==0.29.33
     - name: Install kivy-ios
       run: |
         source .ci/utils.sh

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -5,9 +5,9 @@ jobs:
   pypi_release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
     - name: Install dependencies

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout kivy-ios
-      uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/checkout@v3
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: 3.x
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools wheel twine
@@ -26,7 +26,7 @@ jobs:
         python -m venv venv
         . venv/bin/activate
         pip install dist/kivy-ios-*.tar.gz
-        pip install Cython==0.29.17
+        pip install Cython==0.29.33
         brew install autoconf automake libtool pkg-config
     - name: Basic toolchain commands
       run: |


### PR DESCRIPTION
Q: Do the `apple-silicon-m1` boxes have a version of Python 3.11 on them?

A: On `apple-silicon-m1`:
* [x] `matrix.python: 3.11.1` Pyenv installs Python 3.11.1
* [x] `matrix.python: 3.11` Pyenv installs Python 3.11.1
* [ ] `matrix.python: 3.x` Pyenv ___fails___!