### PR TITLE
Bump `numpy` version to `1.24.2` ( and fix the build on Python 3.10 ✅ )

### DIFF
--- a/kivy_ios/recipes/numpy/__init__.py
+++ b/kivy_ios/recipes/numpy/__init__.py
@@ -5,8 +5,8 @@ import shutil
 
 
 class NumpyRecipe(CythonRecipe):
-    version = "1.20.2"
-    url = "https://pypi.python.org/packages/source/n/numpy/numpy-{version}.zip"
+    version = "1.24.2"
+    url = "https://pypi.python.org/packages/source/n/numpy/numpy-{version}.tar.gz"
     library = "libnumpy.a"
     libraries = ["libnpymath.a", "libnpyrandom.a"]
     include_dir = "numpy/core/include"
@@ -17,6 +17,7 @@ class NumpyRecipe(CythonRecipe):
     def prebuild_arch(self, arch):
         if self.has_marker("patched"):
             return
+        self.apply_patch("skip-math-test.patch")
         self.apply_patch("duplicated_symbols.patch")
         self.set_marker("patched")
 
@@ -51,6 +52,8 @@ class NumpyRecipe(CythonRecipe):
         shutil.rmtree(join(dest_dir, "polynomial", "tests"))
         shutil.rmtree(join(dest_dir, "random", "tests"))
         shutil.rmtree(join(dest_dir, "tests"))
+        sh.rm(join(dest_dir, "core", "lib", "libnpymath.a"))
+        sh.rm(join(dest_dir, "random", "lib", "libnpyrandom.a"))
 
 
 recipe = NumpyRecipe()

--- a/kivy_ios/recipes/numpy/duplicated_symbols.patch
+++ b/kivy_ios/recipes/numpy/duplicated_symbols.patch
@@ -1,23 +1,23 @@
-diff -Naur numpy-1.20.2.orig/numpy/linalg/setup.py numpy-1.20.2/numpy/linalg/setup.py
---- numpy-1.20.2.orig/numpy/linalg/setup.py	2021-04-04 11:04:17.000000000 +0200
-+++ numpy-1.20.2/numpy/linalg/setup.py	2021-04-04 11:04:54.000000000 +0200
-@@ -75,7 +75,7 @@
+diff -Naur numpy-1.24.2.orig/numpy/linalg/setup.py numpy-1.24.2/numpy/linalg/setup.py
+--- numpy-1.24.2.orig/numpy/linalg/setup.py     2023-03-11 19:31:34
++++ numpy-1.24.2/numpy/linalg/setup.py  2023-03-11 19:32:12
+@@ -78,7 +78,7 @@
      # umath_linalg module
      config.add_extension(
          '_umath_linalg',
--        sources=['umath_linalg.c.src', get_lapack_lite_sources],
-+        sources=['umath_linalg.c.src'],
+-        sources=['umath_linalg.cpp', get_lapack_lite_sources],
++        sources=['umath_linalg.cpp'],
          depends=['lapack_lite/f2c.h'],
          extra_info=lapack_info,
-         libraries=['npymath'],
-diff -Naur numpy-1.20.2.orig/numpy/random/setup.py numpy-1.20.2/numpy/random/setup.py
---- numpy-1.20.2.orig/numpy/random/setup.py	2021-04-04 11:04:17.000000000 +0200
-+++ numpy-1.20.2/numpy/random/setup.py	2021-04-04 11:05:22.000000000 +0200
-@@ -127,7 +127,6 @@
+         extra_cxx_compile_args=NPY_CXX_FLAGS,
+diff -Naur numpy-1.24.2.orig/numpy/random/setup.py numpy-1.24.2/numpy/random/setup.py
+--- numpy-1.24.2.orig/numpy/random/setup.py     2023-03-11 19:38:04
++++ numpy-1.24.2/numpy/random/setup.py  2023-03-11 19:39:48
+@@ -139,7 +139,6 @@
      config.add_extension('mtrand',
                           sources=['mtrand.c',
                                    'src/legacy/legacy-distributions.c',
 -                                  'src/distributions/distributions.c',
                                   ],
                           include_dirs=['.', 'src', 'src/legacy'],
-                          libraries=['m'] if os.name != 'nt' else [],
+                          libraries=mtrand_libs,

--- a/kivy_ios/recipes/numpy/skip-math-test.patch
+++ b/kivy_ios/recipes/numpy/skip-math-test.patch
@@ -1,0 +1,83 @@
+diff -Naur numpy-1.24.2.orig/numpy/core/setup.py numpy-1.24.2/numpy/core/setup.py
+--- numpy-1.24.2.orig/numpy/core/setup.py       2023-03-11 19:49:17
++++ numpy-1.24.2/numpy/core/setup.py    2023-03-11 19:51:42
+@@ -429,27 +429,7 @@
+ 
+ def check_mathlib(config_cmd):
+     # Testing the C math library
+-    mathlibs = []
+-    mathlibs_choices = [[], ["m"], ["cpml"]]
+-    mathlib = os.environ.get("MATHLIB")
+-    if mathlib:
+-        mathlibs_choices.insert(0, mathlib.split(","))
+-    for libs in mathlibs_choices:
+-        if config_cmd.check_func(
+-            "log",
+-            libraries=libs,
+-            call_args="0",
+-            decl="double log(double);",
+-            call=True
+-        ):
+-            mathlibs = libs
+-            break
+-    else:
+-        raise RuntimeError(
+-            "math library missing; rerun setup.py after setting the "
+-            "MATHLIB env variable"
+-        )
+-    return mathlibs
++    return ["m"]
+ 
+ 
+ def visibility_define(config):
+@@ -716,49 +696,7 @@
+     subst_dict = dict([("sep", os.path.sep), ("pkgname", "numpy.core")])
+ 
+     def get_mathlib_info(*args):
+-        # Another ugly hack: the mathlib info is known once build_src is run,
+-        # but we cannot use add_installed_pkg_config here either, so we only
+-        # update the substitution dictionary during npymath build
+-        config_cmd = config.get_config_cmd()
+-        # Check that the toolchain works, to fail early if it doesn't
+-        # (avoid late errors with MATHLIB which are confusing if the
+-        # compiler does not work).
+-        for lang, test_code, note in (
+-            ('c', 'int main(void) { return 0;}', ''),
+-            ('c++', (
+-                    'int main(void)'
+-                    '{ auto x = 0.0; return static_cast<int>(x); }'
+-                ), (
+-                    'note: A compiler with support for C++11 language '
+-                    'features is required.'
+-                )
+-             ),
+-        ):
+-            is_cpp = lang == 'c++'
+-            if is_cpp:
+-                # this a workaround to get rid of invalid c++ flags
+-                # without doing big changes to config.
+-                # c tested first, compiler should be here
+-                bk_c = config_cmd.compiler
+-                config_cmd.compiler = bk_c.cxx_compiler()
+-
+-                # Check that Linux compiler actually support the default flags
+-                if hasattr(config_cmd.compiler, 'compiler'):
+-                    config_cmd.compiler.compiler.extend(NPY_CXX_FLAGS)
+-                    config_cmd.compiler.compiler_so.extend(NPY_CXX_FLAGS)
+-
+-            st = config_cmd.try_link(test_code, lang=lang)
+-            if not st:
+-                # rerun the failing command in verbose mode
+-                config_cmd.compiler.verbose = True
+-                config_cmd.try_link(test_code, lang=lang)
+-                raise RuntimeError(
+-                    f"Broken toolchain: cannot link a simple {lang.upper()} "
+-                    f"program. {note}"
+-                )
+-            if is_cpp:
+-                config_cmd.compiler = bk_c
+-        mlibs = check_mathlib(config_cmd)
++        mlibs = check_mathlib(None)
+ 
+         posix_mlib = ' '.join(['-l%s' % l for l in mlibs])
+         msvc_mlib = ' '.join(['%s.lib' % l for l in mlibs])


### PR DESCRIPTION
`numpy==1.20.2` does not work with **Python 3.10** (I noticed it during #778 automated tests).

`numpy==1.24.2` (the latest release), needs some more patching in order to skip a (math library related) check during configuration, but works fine during runtime. (at least with a simple example)

Also fixes: https://github.com/kivy/kivy-ios/issues/682



