### PR TITLE
Fixes crash on ios.get_safe_area() in iOS 16

### DIFF
--- a/kivy_ios/recipes/ios/src/ios_utils.m
+++ b/kivy_ios/recipes/ios/src/ios_utils.m
@@ -158,7 +158,7 @@ int ios_uiscreen_get_dpi() {
 padding ios_get_safe_area() {
 	padding safearea;
 	if (@available(iOS 11.0, *)){
-		UIWindow *window = UIApplication.sharedApplication.windows[0];
+		UIWindow *window = [[[UIApplication sharedApplication] delegate] window];
 		safearea.top = window.safeAreaInsets.top;
 		safearea.bottom = window.safeAreaInsets.bottom;
 		safearea.left = window.safeAreaInsets.left;


### PR DESCRIPTION
Fixes access to windows[0] that crash if not existing. Using delegate works all the time.