### PR TITLE
Use `--no-deps` and `--platform` during install of recipe python deps

### DIFF
--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -945,7 +945,7 @@ class Recipe:
     @cache_execution
     def install_python_deps(self):
         for dep in self.python_depends:
-            _pip(["install", dep])
+            _pip(["install", "--no-deps", "--platform", "any", dep])
 
     @cache_execution
     def install(self):


### PR DESCRIPTION
### Why only for pip installations made via `install_python_deps` and not for everything (e.g `toolchain pip install`) ?
Basically just for not breaking things for users now, since we likely need to write a guide for parsing dependencies, but we're in a rush for releasing `2.2.0rc1` (which need additional `python_deps` compared to `2.1.0`)

### Why `--platform any` ?
Well, packages like `charset-normalizer` (which is a dependency of `requests`) ship to PyPi both platform-specific wheels (like `charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl`) and non-platform specific wheels (`charset_normalizer-3.1.0-py3-none-any.whl`).

In `kivy-ios` we need to ask `pip` to install a non-platform-specific version (otherwise it will install the `macosx` version, which is not compatible with `iOS`)

### Wow. `--platform` seems nice feature, but why `--no-deps`?
Well, unfortunately,  `--platform` does not work alone.
```
ERROR: When restricting platform and interpreter constraints using --python-version, --platform, --abi, or --implementation, either --no-deps must be set, or --only-binary=:all: must be set and --no-binary must not be set (or must be set to :none:).
```