### PR TITLE
Fix duplicate symbols (see #787) since sdl2_ttf links against freetype

### DIFF
--- a/kivy_ios/recipes/freetype/__init__.py
+++ b/kivy_ios/recipes/freetype/__init__.py
@@ -6,7 +6,6 @@ import sh
 class FreetypeRecipe(Recipe):
     version = "2.5.5"
     url = "https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-{version}.tar.bz2"
-    library = "objs/.libs/libfreetype.a"
     include_dir = ["include", ("builds/unix/ftconfig.h", "config/ftconfig.h")]
     include_per_arch = True
 

--- a/kivy_ios/recipes/pillow/__init__.py
+++ b/kivy_ios/recipes/pillow/__init__.py
@@ -11,6 +11,7 @@ class PillowRecipe(CythonRecipe):
     depends = [
         "hostpython3",
         "freetype",
+        "sdl2_ttf",
         "libjpeg",
         "python3",
         "ios",


### PR DESCRIPTION
I know, I know, it might look like a bit of a dumb solution... but we need freetype headers, and those won't be installed alongside sdl2_ttf ; so our best (easiest) solution is simply to make freetype _not_ add its binary to the app, and have pillow rely on sdl2_ttf to provide the symbols instead while still relying on freetype for headers.

Of course if you have better suggestions, they're more than welcome! :-)