### PR TITLE
SDL_ttf: Hide internal symbols via single-object prelink

### DIFF
--- a/kivy_ios/recipes/sdl2_ttf/__init__.py
+++ b/kivy_ios/recipes/sdl2_ttf/__init__.py
@@ -15,6 +15,7 @@ class LibSDL2TTFRecipe(Recipe):
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(arch.arch),
                 "BITCODE_GENERATION_MODE=bitcode",
+                "GENERATE_MASTER_OBJECT_FILE=YES",
                 "HEADER_SEARCH_PATHS={}".format(
                     join(self.ctx.include_dir, "common", "sdl2")),
                 "-sdk", arch.sdk,


### PR DESCRIPTION
Fixes https://github.com/kivy/kivy-ios/issues/787 via single-object prelink, so freetype and harfbuzz symbols are kept internal (as it should be).