### PR TITLE
Update `libpng` recipe and build `SDL2_ttf` vendored `freetype` with png support, so can render colored emoji

### DIFF
--- a/kivy_ios/recipes/libpng/__init__.py
+++ b/kivy_ios/recipes/libpng/__init__.py
@@ -6,7 +6,7 @@ import sh
 
 class PngRecipe(Recipe):
     version = '1.6.40'
-    url = 'https://altushost-swe.dl.sourceforge.net/project/libpng/libpng16/1.6.40/libpng-1.6.40.tar.gz'
+    url = 'https://downloads.sourceforge.net/sourceforge/libpng/libpng-{version}.tar.gz'
     library = 'dist/lib/libpng16.a'
     include_dir = 'dist/include'
 

--- a/kivy_ios/recipes/libpng/__init__.py
+++ b/kivy_ios/recipes/libpng/__init__.py
@@ -5,24 +5,26 @@ import sh
 
 
 class PngRecipe(Recipe):
-    version = '1.6.26'
-    url = 'http://downloads.sourceforge.net/sourceforge/libpng/libpng-{version}.tar.gz'
-    depends = ["python"]
-    library = '.libs/libpng16.a'
+    version = '1.6.40'
+    url = 'https://altushost-swe.dl.sourceforge.net/project/libpng/libpng16/1.6.40/libpng-1.6.40.tar.gz'
+    library = 'dist/lib/libpng16.a'
+    include_dir = 'dist/include'
 
     def build_arch(self, arch):
         build_env = arch.get_env()
         configure = sh.Command(join(self.build_dir, "configure"))
+
         shprint(configure,
                 "CC={}".format(build_env["CC"]),
                 "LD={}".format(build_env["LD"]),
                 "CFLAGS={}".format(build_env["CFLAGS"]),
                 "LDFLAGS={}".format(build_env["LDFLAGS"]),
-                "--prefix=/",
+                "--prefix={}".format(join(self.build_dir, "dist")),
                 "--host={}".format(arch.triple),
                 "--disable-shared")
         shprint(sh.make, "clean")
         shprint(sh.make, self.ctx.concurrent_make, _env=build_env)
+        shprint(sh.make, "install", _env=build_env)
 
 
 recipe = PngRecipe()

--- a/kivy_ios/recipes/sdl2_ttf/__init__.py
+++ b/kivy_ios/recipes/sdl2_ttf/__init__.py
@@ -4,11 +4,11 @@ import sh
 
 
 class LibSDL2TTFRecipe(Recipe):
-    version = "2.20.1"
+    version = "2.20.2"
     url = "https://github.com/libsdl-org/SDL_ttf/releases/download/release-{version}/SDL2_ttf-{version}.tar.gz"
     library = "Xcode/build/Release-{arch.sdk}/libSDL2_ttf.a"
     include_dir = "SDL_ttf.h"
-    depends = ["sdl2"]
+    depends = ["libpng", "sdl2"]
 
     def build_arch(self, arch):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
@@ -16,8 +16,11 @@ class LibSDL2TTFRecipe(Recipe):
                 "ARCHS={}".format(arch.arch),
                 "BITCODE_GENERATION_MODE=bitcode",
                 "GENERATE_MASTER_OBJECT_FILE=YES",
-                "HEADER_SEARCH_PATHS={}".format(
-                    join(self.ctx.include_dir, "common", "sdl2")),
+                "HEADER_SEARCH_PATHS={sdl_include_dir} {libpng_include_dir}".format(
+                    sdl_include_dir=join(self.ctx.include_dir, "common", "sdl2"),
+                    libpng_include_dir=join(self.ctx.include_dir, "common", "libpng"),
+                ),
+                "GCC_PREPROCESSOR_DEFINITIONS=$(GCC_PREPROCESSOR_DEFINITIONS) FT_CONFIG_OPTION_USE_PNG=1",
                 "-sdk", arch.sdk,
                 "-project", "Xcode/SDL_ttf.xcodeproj",
                 "-target", "Static Library",


### PR DESCRIPTION
See: https://github.com/kivy/kivy/issues/7565

`Apple Color Emoji` and other system fonts are not accessible on iOS, as are located outside of the app sandbox, so the user will need to use an alternative font ATM.

PS: Accessing the system fonts is feasible, via `CGFont` methods (by reconstructing a .ttf file), and we likely want to introduce this feature on `kivy/kivy`.

Demo:
```python
from kivy.app import App
from kivy.lang import Builder
from kivy.uix.boxlayout import BoxLayout


class UI(BoxLayout):
    pass


Builder.load_string(
    """
<UI>:
    Label:
        text: "😀 🎉 📷 👕 🐞"
        font_size: dp(80)
        font_name: "./NotoColorEmoji_WindowsCompatible.ttf"
"""
)


class Testapp(App):
    def build(self):
        return UI()


Testapp().run()
```

Output:
![IMG_0065](https://github.com/kivy/kivy-ios/assets/8177736/736882f4-fe60-487a-841c-9ddc353f5253)

