### PR TITLE
Lock Cython to 0.29.17 in Numpy recipe

### DIFF
--- a/kivy_ios/recipes/numpy/__init__.py
+++ b/kivy_ios/recipes/numpy/__init__.py
@@ -11,7 +11,7 @@ class NumpyRecipe(CythonRecipe):
     libraries = ["libnpymath.a", "libnpyrandom.a"]
     include_dir = "numpy/core/include"
     depends = ["python"]
-    hostpython_prerequisites = ["Cython"]
+    hostpython_prerequisites = ["Cython==0.29.17"]
     cythonize = False
 
     def prebuild_arch(self, arch):


### PR DESCRIPTION
`cython` 3.0.0 was released yesterday and building `numpy` < 1.25.0 is not supported with `cython` 3.0 or newer. Without locking to a specific `cython` version, pip will grab the latest and `numpy` will fail to build.

I'm relatively new to using Kivy, so there may be a better way to accomplish this than changing the recipe file.