### PR TITLE
Remove Unused Dependency: Requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pbxproj==3.5.0
 Pillow>=6.1.0
-requests>=2.13
 cookiecutter==2.1.1
 sh==1.12.14
 Cython==0.29.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ install_requires =
     cookiecutter
     pbxproj
     Pillow
-    requests
     sh
 packages = find:
 # note this is a bit excessive as it includes absolutely everything


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `requests` from the `setup.cfg` and the `requirements.txt` configuration files. The detection and removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `requests` dependency was initially introduced in [this pull request](https://github.com/kivy/kivy-ios/pull/332) to support Python 2. However, the related Python 2 logic was removed in [this pull request](https://github.com/kivy/kivy-ios/pull/484), rendering the dependency unnecessary. Despite its removal from the source code, `requests` remained listed as a requirement in the project's dependency files. By eliminating this unused dependency, the overall footprint of the application is reduced, mitigating potential security risks and simplifying the dependency management process.

## Changes

- Removed the `requests` dependency from the `setup.cfg` file.

## Impact

- **Reduced Package Size**: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- **Simplified Dependency Tree**: Fewer dependencies make the project easier to maintain and can speed up installation.