### PR TITLE
Use a pinned version of `Cython` for now, as most of the recipes are incompatible with `Cython==3.x.x`

### DIFF
--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -38,7 +38,7 @@ jobs:
         pip3 install -r requirements.txt
         brew install autoconf automake libtool pkg-config
         brew link libtool
-        pip3 install Cython==0.29.33
+        pip3 install Cython==0.29.36
         sudo gem install xcpretty
     - name: Install kivy-ios
       run: |
@@ -77,7 +77,7 @@ jobs:
         pip install sh
         brew install autoconf automake libtool pkg-config
         brew link libtool
-        pip install Cython==0.29.33
+        pip install Cython==0.29.36
         sudo gem install xcpretty
     - name: Install kivy-ios
       run: |
@@ -116,7 +116,7 @@ jobs:
         pip3 install -r requirements.txt
         brew install autoconf automake libtool pkg-config
         brew link libtool
-        pip3 install Cython==0.29.33
+        pip3 install Cython==0.29.36
     - name: Install kivy-ios
       run: |
         python setup.py install

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -26,7 +26,7 @@ jobs:
         python -m venv venv
         . venv/bin/activate
         pip install dist/kivy-ios-*.tar.gz
-        pip install Cython==0.29.33
+        pip install Cython==0.29.36
         brew install autoconf automake libtool pkg-config
     - name: Basic toolchain commands
       run: |

--- a/kivy_ios/recipes/numpy/__init__.py
+++ b/kivy_ios/recipes/numpy/__init__.py
@@ -11,7 +11,7 @@ class NumpyRecipe(CythonRecipe):
     libraries = ["libnpymath.a", "libnpyrandom.a"]
     include_dir = "numpy/core/include"
     depends = ["python"]
-    hostpython_prerequisites = ["Cython"]
+    hostpython_prerequisites = ["Cython==0.29.36"]
     cythonize = False
 
     def prebuild_arch(self, arch):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Pillow>=6.1.0
 requests>=2.13
 cookiecutter==2.1.1
 sh==1.12.14
-Cython==0.29.17
+Cython==0.29.36

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ url = https://github.com/kivy/kivy-ios
 [options]
 python_requires >= "3.6.0"
 install_requires =
-    Cython
+    Cython==0.29.36
     cookiecutter
     pbxproj
     Pillow


### PR DESCRIPTION
`Cython>=3.0.0` broke our CI pipeline.

But it's not `Cython` fault, instead, we urge to change our `python-for-android` and `kivy-ios` logic to not rely on a single specific `Cython` version for all the packages, as every package should be able to decide the `Cython` (and other build-time-only packages to use).

Meanwhile, to keep the development up and running, that seems the faster solution.

(See https://github.com/kivy/buildozer/pull/1637 and https://github.com/kivy/python-for-android/pull/2862)