### PR TITLE
Bump `numpy` version to `1.24.4`

### DIFF
--- a/kivy_ios/recipes/numpy/__init__.py
+++ b/kivy_ios/recipes/numpy/__init__.py
@@ -5,7 +5,7 @@ import shutil
 
 
 class NumpyRecipe(CythonRecipe):
-    version = "1.24.2"
+    version = "1.24.4"
     url = "https://pypi.python.org/packages/source/n/numpy/numpy-{version}.tar.gz"
     library = "libnumpy.a"
     libraries = ["libnpymath.a", "libnpyrandom.a"]


### PR DESCRIPTION
Not really needed or required, except that keeping the recipe updated is just a good idea.

The main reason for this PR is to test the `numpy` build on CI/CD, since https://github.com/kivy/kivy-ios/pull/778 `Updated recipes` job seems to fail on `numpy`, for an unknown reason. (works locally)