### PR TITLE
update for recent iOS platform changes

### DIFF
--- a/kivy_ios/recipes/kiwisolver/__init__.py
+++ b/kivy_ios/recipes/kiwisolver/__init__.py
@@ -22,8 +22,8 @@ class KiwiSolverRecipe(CythonRecipe):
     cythonize = False
     library = "libkiwisolver.a"
 
-    def get_recipe_env(self, arch=None, with_flags_in_cc=True):
-        env = super().get_recipe_env(arch)
+    def get_recipe_env(self, plat):
+        env = super().get_recipe_env(plat)
 
         # cpplink setup
         env['CXX_ORIG'] = env['CXX']

--- a/kivy_ios/recipes/matplotlib/setup.py.patch
+++ b/kivy_ios/recipes/matplotlib/setup.py.patch
@@ -1,5 +1,14 @@
 --- matplotlib-3.5.2.orig/setup.py	2022-05-02 22:49:57
-+++ matplotlib-3.5.2/setup.py	2023-09-09 22:22:57
++++ matplotlib-3.5.2/setup.py	2023-09-10 11:11:57
+@@ -47,7 +47,7 @@
+     setupext.FreeType(),
+     setupext.Qhull(),
+     setupext.Tests(),
+-    setupext.BackendMacOSX(),
++#    setupext.BackendMacOSX(),
+     ]
+ 
+ 
 @@ -315,7 +315,7 @@
      python_requires='>={}'.format('.'.join(str(n) for n in py_min_version)),
      setup_requires=[

--- a/kivy_ios/recipes/matplotlib/setupext.py.patch
+++ b/kivy_ios/recipes/matplotlib/setupext.py.patch
@@ -1,5 +1,5 @@
 --- matplotlib-3.5.2.orig/setupext.py	2023-09-08 14:01:18
-+++ matplotlib-3.5.2/setupext.py	2023-09-09 22:23:24
++++ matplotlib-3.5.2/setupext.py	2023-09-10 11:29:38
 @@ -404,7 +404,7 @@
              "matplotlib._contour", [
                  "src/_contour.cpp",
@@ -53,3 +53,45 @@
      ext.define_macros.extend([
          # Ensure that PY_ARRAY_UNIQUE_SYMBOL is uniquely defined for each
          # extension.
+@@ -749,22 +749,22 @@
+                 ext.libraries.extend("m")
+ 
+ 
+-class BackendMacOSX(OptionalPackage):
+-    config_category = 'gui_support'
+-    name = 'macosx'
+-
+-    def check(self):
+-        if sys.platform != 'darwin':
+-            raise Skipped("Mac OS-X only")
+-        return super().check()
+-
+-    def get_extensions(self):
+-        sources = [
+-            'src/_macosx.m'
+-            ]
+-        ext = Extension('matplotlib.backends._macosx', sources)
+-        ext.extra_compile_args.extend(['-Werror=unguarded-availability'])
+-        ext.extra_link_args.extend(['-framework', 'Cocoa'])
+-        if platform.python_implementation().lower() == 'pypy':
+-            ext.extra_compile_args.append('-DPYPY=1')
+-        yield ext
++#class BackendMacOSX(OptionalPackage):
++#    config_category = 'gui_support'
++#    name = 'macosx'
++#
++#    def check(self):
++#        if sys.platform != 'darwin':
++#            raise Skipped("Mac OS-X only")
++#        return super().check()
++#
++#    def get_extensions(self):
++#        sources = [
++#            'src/_macosx.m'
++#            ]
++#        ext = Extension('matplotlib.backends._macosx', sources)
++#        ext.extra_compile_args.extend(['-Werror=unguarded-availability'])
++#        ext.extra_link_args.extend(['-framework', 'Cocoa'])
++#        if platform.python_implementation().lower() == 'pypy':
++#            ext.extra_compile_args.append('-DPYPY=1')
++#        yield ext

--- a/kivy_ios/tools/cpplink
+++ b/kivy_ios/tools/cpplink
@@ -100,10 +100,14 @@ def call_linker(objects, output):
     print('cpplink redirect linking with', objects)
     ld = environ.get('ARM_LD')
     arch = environ.get('ARCH', 'arm64')
-    if 'arm' in arch:
+    sdk = environ.get('PLATFORM_SDK', 'iphoneos')
+    if sdk == 'iphoneos':
         min_version_flag = '-ios_version_min'
-    else:
+    elif sdk == 'iphonesimulator':
         min_version_flag = '-ios_simulator_version_min'
+    else:
+        raise ValueError("Unsupported SDK: {}".format(sdk))
+
     call = [ld, '-r', '-o', output + '.o', min_version_flag, '9.0', '-arch', arch]
     if min_version_flag == "-ios_version_min":
         call += ["-bitcode_bundle"]


### PR DESCRIPTION
Fix matplotlib build for new iOS changes.  Asking for some feedback from @misl6

Creates:
```
dist/lib/iphoneos/libmatplotlib.a
dist/lib/iphonesimulator/libmatplotlib.a
```

when built on m1