### PR TITLE
Do not use full path for system libraries and frameworks in `.xcodeproj`

### DIFF
--- a/.ci/test_project.sh
+++ b/.ci/test_project.sh
@@ -5,7 +5,22 @@ set -eo pipefail
 
 toolchain create Touchtracer kivy-ci-clone/examples/demo/touchtracer
 
+# If runner arch is arm64, then the simulator arch is arm64,
+# otherwise it's x86_64
+if [ $(arch) == "arm64" ]; then
+    SIM_ARCH="arm64"
+else
+    SIM_ARCH="x86_64"
+fi
+
+# Build for iOS
 xcodebuild -project touchtracer-ios/touchtracer.xcodeproj \
             -scheme touchtracer \
             -destination generic/platform=iOS\
             clean build CODE_SIGNING_ALLOWED=NO | xcpretty
+
+# Build for iOS Simulator
+xcodebuild -project touchtracer-ios/touchtracer.xcodeproj \
+            -scheme touchtracer \
+            -destination 'generic/platform=iOS Simulator' \
+            clean build CODE_SIGNING_ALLOWED=NO ARCHS=$SIM_ARCH | xcpretty

--- a/kivy_ios/recipes/zbarlight/__init__.py
+++ b/kivy_ios/recipes/zbarlight/__init__.py
@@ -12,7 +12,8 @@ class ZbarLightRecipe(Recipe):
     url = "https://github.com/Polyconseil/zbarlight/archive/{version}.tar.gz"
     library = "zbarlight.a"
     depends = ["hostpython3", "python3", "libzbar"]
-    pbx_libraries = ["libz", "libbz2", "libc++", "libsqlite3", "CoreMotion"]
+    pbx_libraries = ["libz", "libbz2", "libc++", "libsqlite3"]
+    pbx_frameworks = ["CoreMotion"]
     include_per_platform = True
 
     def get_zbar_env(self, plat):


### PR DESCRIPTION
XCode 15 fails to build the App if the specified full path of a system library or framework is different from the target destination.

E.g: If the target destination is a real iOS device, and the specified full path is for the Simulator, it will fail to build for the real iOS device, and vice-versa.

This PR:
- Does not use the full path while specifying a system library or framework
- Adds a test build on iOS Simulator (so we can make sure that the generated `.xcodeproj` also works on Simulator)
-  Fixes a potential issue on `zbarlight` recipe (`CoreMotion` is a framework, not a library)