### PR TITLE
Install kivy-ios via pip during tests, so dependencies are automatically managed

### DIFF
--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -35,14 +35,13 @@ jobs:
       run: |
         brew install libjpeg
         pip3 install wheel
-        pip3 install -r requirements.txt
         brew install autoconf automake libtool pkg-config
         brew link libtool
         pip3 install Cython==0.29.36
         sudo gem install xcpretty
     - name: Install kivy-ios
       run: |
-        python setup.py install
+        pip install .
     - name: Build Python & Kivy
       run: |
         toolchain build python3 kivy
@@ -73,7 +72,6 @@ jobs:
         . venv/bin/activate
         brew install libjpeg
         pip install wheel
-        pip install -r requirements.txt
         pip install sh
         brew install autoconf automake libtool pkg-config
         brew link libtool
@@ -81,7 +79,7 @@ jobs:
         sudo gem install xcpretty
     - name: Install kivy-ios
       run: |
-        python setup.py install
+        pip install .
     - name: Build Python & Kivy
       run: |
         . venv/bin/activate
@@ -113,13 +111,12 @@ jobs:
       run: |
         brew install libjpeg
         pip3 install wheel
-        pip3 install -r requirements.txt
         brew install autoconf automake libtool pkg-config
         brew link libtool
         pip3 install Cython==0.29.36
     - name: Install kivy-ios
       run: |
-        python setup.py install
+        pip install .
     - name: Build updated recipes
       run: |
         python3 .ci/rebuild_updated_recipes.py


### PR DESCRIPTION
- We were still relying on `python setup.py install`, which does not handle automatically build-time dependencies (like `setuptools`)
- `setuptools` is not included anymore by default from `Python 3.12` and onwards, so the CI started to fail.
- Testing the install via `pip` looks like a better idea. 😀