### PR TITLE
Set `fetch-depth: 0` for updated recipes checkout and use `actions/checkout@v4` instead of `actions/checkout@v3`

### DIFF
--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout kivy-ios
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -26,7 +26,7 @@ jobs:
         runs_on: [macos-latest, apple-silicon-m1]
     steps:
     - name: Checkout kivy-ios
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
@@ -46,7 +46,7 @@ jobs:
       run: |
         toolchain build python3 kivy
     - name: Checkout kivy for tests apps
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: kivy/kivy
         path: kivy-ci-clone
@@ -61,7 +61,7 @@ jobs:
         runs_on: [macos-latest, apple-silicon-m1]
     steps:
     - name: Checkout kivy-ios
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:
@@ -85,7 +85,7 @@ jobs:
         . venv/bin/activate
         toolchain build python3 kivy
     - name: Checkout kivy for tests apps
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: kivy/kivy
         path: kivy-ci-clone
@@ -101,8 +101,10 @@ jobs:
       matrix:
         runs_on: [macos-latest, apple-silicon-m1]
     steps:
-    - name: Checkout kivy-ios
-      uses: actions/checkout@v3
+    - name: Checkout kivy-ios (all-history)
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -5,7 +5,7 @@ jobs:
   pypi_release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout kivy-ios
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python 3.x
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Similar issue of https://github.com/kivy/python-for-android/pull/2496