### PR TITLE
Bump Kivy version to 2.3.0

### DIFF
--- a/kivy_ios/recipes/kivy/__init__.py
+++ b/kivy_ios/recipes/kivy/__init__.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class KivyRecipe(CythonRecipe):
-    version = "2.2.1"
+    version = "2.3.0"
     url = "https://github.com/kivy/kivy/archive/{version}.zip"
     library = "libkivy.a"
     depends = ["sdl2", "sdl2_image", "sdl2_mixer", "sdl2_ttf", "ios",


### PR DESCRIPTION
Bump `kivy` version to `2.3.0` (latest release)