### PR TITLE
Remove bitcode support, as is now deprecated by Apple

### DIFF
--- a/kivy_ios/recipes/libffi/__init__.py
+++ b/kivy_ios/recipes/libffi/__init__.py
@@ -30,7 +30,6 @@ class LibffiRecipe(Recipe):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(plat.arch),
-                "BITCODE_GENERATION_MODE=bitcode",
                 "-sdk", plat.sdk,
                 "-project", "libffi.xcodeproj",
                 "-target", "libffi-iOS",

--- a/kivy_ios/recipes/python3/__init__.py
+++ b/kivy_ios/recipes/python3/__init__.py
@@ -56,7 +56,7 @@ class Python3Recipe(Recipe):
         shprint(configure,
                 "CC={}".format(build_env["CC"]),
                 "LD={}".format(build_env["LD"]),
-                "CFLAGS={}".format(build_env["CFLAGS"].replace("-fembed-bitcode", "")),
+                "CFLAGS={}".format(build_env["CFLAGS"]),
                 "LDFLAGS={} -undefined dynamic_lookup".format(build_env["LDFLAGS"]),
                 "ac_cv_file__dev_ptmx=yes",
                 "ac_cv_file__dev_ptc=no",

--- a/kivy_ios/recipes/sdl2/__init__.py
+++ b/kivy_ios/recipes/sdl2/__init__.py
@@ -24,7 +24,6 @@ class LibSDL2Recipe(Recipe):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(plat.arch),
-                "BITCODE_GENERATION_MODE=bitcode",
                 "CC={}".format(env['CC']),
                 "-sdk", plat.sdk,
                 "-project", "Xcode/SDL/SDL.xcodeproj",

--- a/kivy_ios/recipes/sdl2_image/__init__.py
+++ b/kivy_ios/recipes/sdl2_image/__init__.py
@@ -15,7 +15,6 @@ class LibSDL2ImageRecipe(Recipe):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(plat.arch),
-                "BITCODE_GENERATION_MODE=bitcode",
                 "HEADER_SEARCH_PATHS={}".format(
                     join(self.ctx.include_dir, "common", "sdl2")),
                 "-sdk", plat.sdk,

--- a/kivy_ios/recipes/sdl2_mixer/__init__.py
+++ b/kivy_ios/recipes/sdl2_mixer/__init__.py
@@ -18,7 +18,6 @@ class LibSDL2MixerRecipe(Recipe):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(plat.arch),
-                "BITCODE_GENERATION_MODE=bitcode",
                 "HEADER_SEARCH_PATHS=$HEADER_SEARCH_PATHS /usr/include/machine {} ".format(" ".join(plat.include_dirs)),
                 "-sdk", plat.sdk,
                 "-project", "Xcode/SDL_mixer.xcodeproj",

--- a/kivy_ios/recipes/sdl2_ttf/__init__.py
+++ b/kivy_ios/recipes/sdl2_ttf/__init__.py
@@ -14,7 +14,6 @@ class LibSDL2TTFRecipe(Recipe):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",
                 "ARCHS={}".format(plat.arch),
-                "BITCODE_GENERATION_MODE=bitcode",
                 "GENERATE_MASTER_OBJECT_FILE=YES",
                 "HEADER_SEARCH_PATHS={sdl_include_dir} {libpng_include_dir}".format(
                     sdl_include_dir=join(self.ctx.include_dir, "common", "sdl2"),

--- a/kivy_ios/toolchain.py
+++ b/kivy_ios/toolchain.py
@@ -250,8 +250,6 @@ class GenericPlatform:
             "-O3",
             self.version_min,
         ] + include_dirs)
-        if self.sdk == "iphoneos":
-            env["CFLAGS"] += " -fembed-bitcode"
         env["LDFLAGS"] = " ".join([
             "-arch", self.arch,
             # "--sysroot", self.sysroot,

--- a/kivy_ios/tools/cpplink
+++ b/kivy_ios/tools/cpplink
@@ -109,8 +109,6 @@ def call_linker(objects, output):
         raise ValueError("Unsupported SDK: {}".format(sdk))
 
     call = [ld, '-r', '-o', output + '.o', min_version_flag, '9.0', '-arch', arch]
-    if min_version_flag == "-ios_version_min":
-        call += ["-bitcode_bundle"]
     call += objects
     print("Linking: {}".format(" ".join(call)))
     result = subprocess.run(call)

--- a/kivy_ios/tools/liblink
+++ b/kivy_ios/tools/liblink
@@ -87,8 +87,6 @@ elif sdk == 'iphonesimulator':
 else:
     raise ValueError("Unsupported SDK: {}".format(sdk))
 call = [ld, '-r', '-o', output + '.o', min_version_flag, '9.0', '-arch', arch]
-if min_version_flag == "-ios_version_min":
-    call += ["-bitcode_bundle"]
 call += objects
 print("Linking: {}".format(" ".join(call)))
 subprocess.call(call)


### PR DESCRIPTION
From https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-14-release-notes#Deprecations:

> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.
Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release. IPAs that contain bitcode will have the bitcode stripped before being submitted to the App Store. Debug symbols can only be downloaded from App Store Connect / TestFlight for existing bitcode submissions and are no longer available for submissions made with Xcode 14. (86118779)

Latest XCode version is now **15.2**, and bitcode make integration with other libraries more complex (e.g. ANGLE, which is coming soon)

This PR completely removes bitcode support.