### PR TITLE
Bump minimum Python supported version to `3.8`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifiers =
     Intended Audience :: Developers
     Topic :: Software Development :: Build Tools
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,7 +25,7 @@ project_urls =
     Bug Reports=https://github.com/kivy/kivy-ios/issues
 
 [options]
-python_requires >= "3.6.0"
+python_requires >= "3.8.0"
 install_requires =
     Cython==0.29.36
     cookiecutter


### PR DESCRIPTION
Just bumps minimum Python supported version to `3.8`.

(`3.6` and `3.7` reached EOL)