### PR TITLE
fix build for Xcode 16

### DIFF
--- a/kivy_ios/recipes/libffi/__init__.py
+++ b/kivy_ios/recipes/libffi/__init__.py
@@ -22,6 +22,10 @@ class LibffiRecipe(Recipe):
                 "-i.bak",
                 "s/build_target(ios_simulator_i386_platform, platform_headers)/print('Skipping i386')/g",
                 "generate-darwin-source-and-headers.py")
+        shprint(sh.sed,
+                "-i.bak",
+                "s/ -fembed-bitcode//g",
+                "generate-darwin-source-and-headers.py")
         self.set_marker("patched")
 
     def build_platform(self, plat):

--- a/kivy_ios/recipes/sdl2_ttf/__init__.py
+++ b/kivy_ios/recipes/sdl2_ttf/__init__.py
@@ -10,6 +10,14 @@ class LibSDL2TTFRecipe(Recipe):
     include_dir = "SDL_ttf.h"
     depends = ["libpng", "sdl2"]
 
+    def prebuild_platform(self, plat):
+        if self.has_marker("patched"):
+            return
+
+        self.apply_patch("harfbuzz.patch")
+
+        self.set_marker("patched")
+
     def build_platform(self, plat):
         shprint(sh.xcodebuild, self.ctx.concurrent_xcodebuild,
                 "ONLY_ACTIVE_ARCH=NO",

--- a/kivy_ios/recipes/sdl2_ttf/harfbuzz.patch
+++ b/kivy_ios/recipes/sdl2_ttf/harfbuzz.patch
@@ -1,0 +1,13 @@
+
+diff -Naur SDL2_ttf-2.20.2.orig/external/harfbuzz/src/hb-ft.cc SDL2_ttf-2.20.2/external/harfbuzz/src/hb-ft.cc
+--- SDL2_ttf-2.20.2.orig/external/harfbuzz/src/hb-ft.cc	2022-05-25 12:51:24
++++ SDL2_ttf-2.20.2/external/harfbuzz/src/hb-ft.cc	2024-09-24 21:33:24
+@@ -41,6 +41,8 @@
+ #include FT_MULTIPLE_MASTERS_H
+ #include FT_TRUETYPE_TABLES_H
+ 
++/** function pointer warning with XCode 16 */
++#pragma clang diagnostic ignored "-Wcast-function-type-strict"
+ 
+ /**
+  * SECTION:hb-ft


### PR DESCRIPTION
Fix issues with Xcode 16 build (Issue #936)

Prerequisites:
* remove homebrew from your system PATH as compiling an extension module targeting iOS accidentally catches stuff in compiled modules for homebrew

Compiles all of the components for:
```
toolchain build kivy
```
Note that other recipes will probably need adapting.
