### PR TITLE
Upgrade itsdangerous recipe to 2.2.0

### DIFF
--- a/kivy_ios/recipes/itsdangerous/__init__.py
+++ b/kivy_ios/recipes/itsdangerous/__init__.py
@@ -6,19 +6,19 @@ import sh
 
 
 class ItsDangerousRecipe(PythonRecipe):
-    version = "1.1.0"
+    version = "2.2.0"
     url = "https://github.com/mitsuhiko/itsdangerous/archive/{version}.zip"
     depends = ["python"]
 
     def install(self):
         plat = list(self.platforms_to_build)[0]
         build_dir = self.get_build_dir(plat)
-        hostpython = sh.Command(self.ctx.hostpython)
+        hostpython_pip = sh.Command(join(self.ctx.dist_dir, "hostpython3", "bin", "pip3"))
         build_env = plat.get_env()
         dest_dir = join(self.ctx.dist_dir, "root", "python3")
         build_env['PYTHONPATH'] = self.ctx.site_packages_dir
         with cd(build_dir):
-            shprint(hostpython, "setup.py", "install", "--prefix", dest_dir, _env=build_env)
+            shprint(hostpython_pip, "install", build_dir, "--prefix", dest_dir, _env=build_env)
 
 
 recipe = ItsDangerousRecipe()


### PR DESCRIPTION
itsdangerous version 2.2.0 eliminated their setup.py, so all toolchain builds of itsdangerous fails due to missing setup.py.

This patch updates the recipe for itsdangerous to run pip to install the 2.2.0 version.