### PR TITLE
Fix ios deploy target

### DIFF
--- a/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/{{ cookiecutter.project_name }}.xcodeproj/project.pbxproj
+++ b/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/{{ cookiecutter.project_name }}.xcodeproj/project.pbxproj
@@ -292,7 +292,7 @@
 					"{{ cookiecutter.dist_dir }}/include/common/sdl2",
 				);
 				INFOPLIST_FILE = "{{ cookiecutter.project_name }}-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"{{ cookiecutter.dist_dir }}/lib",

--- a/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/{{ cookiecutter.project_name }}.xcodeproj/project.pbxproj
+++ b/kivy_ios/tools/templates/{{ cookiecutter.project_name }}-ios/{{ cookiecutter.project_name }}.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 					"{{ cookiecutter.dist_dir }}/include/common/sdl2",
 				);
 				INFOPLIST_FILE = "{{ cookiecutter.project_name }}-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"{{ cookiecutter.dist_dir }}/lib",


### PR DESCRIPTION
I just upgraded the latest supported `IPHONEOS_DEPLOYMENT_TARGET to 17.0` as `XCODE>=13.0` supports `12.0 to 17.5.5` latest.
Please consider this.