### PR TITLE
Bump Kivy version to 2.3.1

### DIFF
--- a/kivy_ios/recipes/kivy/__init__.py
+++ b/kivy_ios/recipes/kivy/__init__.py
@@ -7,12 +7,19 @@ logger = logging.getLogger(__name__)
 
 
 class KivyRecipe(CythonRecipe):
-    version = "2.3.0"
+    version = "2.3.1"
     url = "https://github.com/kivy/kivy/archive/{version}.zip"
     library = "libkivy.a"
     depends = ["sdl2", "sdl2_image", "sdl2_mixer", "sdl2_ttf", "ios",
                "pyobjus", "python"]
-    python_depends = ["certifi", "charset-normalizer", "idna", "requests", "urllib3"]
+    python_depends = [
+        "certifi",
+        "charset-normalizer",
+        "idna",
+        "requests",
+        "urllib3",
+        "filetype",
+    ]
     pbx_frameworks = ["OpenGLES", "Accelerate", "CoreMedia", "CoreVideo"]
     pre_build_ext = True
 


### PR DESCRIPTION
- Bump Kivy version in recipe to `2.3.1`
- Add `filetype` to Kivy's python dependencies