### PR TITLE
Disable iOS armv7 build for `libffi`

### DIFF
--- a/kivy_ios/recipes/libffi/__init__.py
+++ b/kivy_ios/recipes/libffi/__init__.py
@@ -3,7 +3,7 @@ import sh
 
 
 class LibffiRecipe(Recipe):
-    version = "3.4.4"
+    version = "3.4.8"
     url = "https://github.com/libffi/libffi/releases/download/v{version}/libffi-{version}.tar.gz"
     library = "build/Release-{plat.sdk}/libffi.a"
     include_per_platform = True
@@ -14,9 +14,14 @@ class LibffiRecipe(Recipe):
         if self.has_marker("patched"):
             return
         self.apply_patch("enable-tramp-build.patch")
+        self.apply_patch("disable-armv7-xcodeproj.patch")
         shprint(sh.sed,
                 "-i.bak",
                 "s/-miphoneos-version-min=7.0/-miphoneos-version-min=9.0/g",
+                "generate-darwin-source-and-headers.py")
+        shprint(sh.sed,
+                "-i.bak",
+                "s/build_target(ios_device_armv7_platform, platform_headers)/print('skipping armv7')/g",
                 "generate-darwin-source-and-headers.py")
         shprint(sh.sed,
                 "-i.bak",

--- a/kivy_ios/recipes/libffi/disable-armv7-xcodeproj.patch
+++ b/kivy_ios/recipes/libffi/disable-armv7-xcodeproj.patch
@@ -1,0 +1,15 @@
+diff -Naur libffi-3.4.8.orig/libffi.xcodeproj/project.pbxproj libffi-3.4.8/libffi.xcodeproj/project.pbxproj
+--- libffi-3.4.8.orig/libffi.xcodeproj/project.pbxproj	2025-05-07 20:23:47
++++ libffi-3.4.8/libffi.xcodeproj/project.pbxproj	2025-05-07 20:24:07
+@@ -87,11 +87,9 @@
+ 			files = (
+ 				FDB52FD01F614A8B00AA92E6 /* ffi.h in CopyFiles */,
+ 				FDB52FD11F614AA700AA92E6 /* ffi_arm64.h in CopyFiles */,
+-				FDB52FD21F614AAB00AA92E6 /* ffi_armv7.h in CopyFiles */,
+ 				FDB52FD41F614AB500AA92E6 /* ffi_x86_64.h in CopyFiles */,
+ 				FDB52FD81F614B8700AA92E6 /* ffitarget.h in CopyFiles */,
+ 				FDB52FD91F614B8E00AA92E6 /* ffitarget_arm64.h in CopyFiles */,
+-				FDB52FDA1F614B9300AA92E6 /* ffitarget_armv7.h in CopyFiles */,
+ 				FDB52FDD1F614BA900AA92E6 /* ffitarget_x86_64.h in CopyFiles */,
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
- On newer Xcode versions, the test program can't link due to missing symbols.
- It was never used (at least in the last decade), as armv7 devices have been deprecated by Apple a long time ago.
- Bumped to latest libffi release version during the process