### PR TITLE
Bump `libpng` version to `1.6.48`

### DIFF
--- a/kivy_ios/recipes/libpng/__init__.py
+++ b/kivy_ios/recipes/libpng/__init__.py
@@ -5,7 +5,7 @@ import sh
 
 
 class PngRecipe(Recipe):
-    version = '1.6.40'
+    version = '1.6.48'
     url = 'https://downloads.sourceforge.net/sourceforge/libpng/libpng-{version}.tar.gz'
     library = 'dist/lib/libpng16.a'
     include_dir = 'dist/include'


### PR DESCRIPTION
- Bump `libpng` version to `1.6.48`
- Fixes an issue on recent Xcode versions regarding `fp.h` while performing `libpng` build.