### PR TITLE
Use `-platform_version` flag during linking instead of the deprecated and now removed) `-ios_simulator_version_min`

### DIFF
--- a/kivy_ios/tools/liblink
+++ b/kivy_ios/tools/liblink
@@ -84,12 +84,23 @@ ld = environ.get('ARM_LD')
 arch = environ.get('ARCH', 'arm64')
 sdk = environ.get('PLATFORM_SDK', 'iphoneos')
 if sdk == 'iphoneos':
-    min_version_flag = '-ios_version_min'
+    platform_version_name = 'ios'
 elif sdk == 'iphonesimulator':
-    min_version_flag = '-ios_simulator_version_min'
+    platform_version_name = 'ios-simulator'
 else:
     raise ValueError("Unsupported SDK: {}".format(sdk))
-call = [ld, '-r', '-o', output + '.o', min_version_flag, '9.0', '-arch', arch]
+call = [
+    ld,
+    "-r",
+    "-o",
+    output + ".o",
+    "-platform_version",
+    platform_version_name,
+    "9.0",
+    "9.0",
+    "-arch",
+    arch,
+]
 call += objects
 print("Linking: {}".format(" ".join(call)))
 subprocess.call(call)


### PR DESCRIPTION
Replaced the deprecated `-ios_version_min` and `-ios_simulator_version_min` flags with the `-platform_version` flag, which is now the recommended approach for specifying platform versions. This change ensures compatibility with both `iphoneos` and `iphonesimulator` SDKs.