### PR TITLE
GitHub Actions: Fix No Response cron job to run just once per day

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
   schedule:
     # Schedule for an arbitrary time (5am) once every day
-    - cron: '* 5 * * *'
+    - cron: '0 5 * * *'
 
 jobs:
   noResponse:


### PR DESCRIPTION
Updated `cron` schedule to run once per day at 5am instead of once every minute between 5:00am and 5:59am.
```diff
  schedule:
    # Schedule for an arbitrary time (5am) once every day
-   - cron: '* 5 * * *'
+   - cron: '0 5 * * *'
```
Hovering over the cron string in GitHub's web UI will pop up an explanation of the schedule:
<img width="568" height="120" alt="cron star 5 star star star" src="https://github.com/user-attachments/assets/3b19151d-1f7d-419d-9555-bb694a0cf2d9" />
-->
<img width="560" height="120" alt="cron 0 5 star star star" src="https://github.com/user-attachments/assets/dc6edc6e-3293-4c9c-bc31-89363f0b920e" />

Proof of a problem: https://github.com/kivy/kivy-ios/actions/workflows/no-response.yml
* https://github.com/kivy/kivy-ios/pull/879/files

@misl6 @Julian-O 

GitHub Actions jobs seem to be [auto-canceled](https://github.com/kivy/kivy-ios/actions) on this repo, perhaps because of so many jobs being run each day.
* Perhaps not...  macOS GitHub Actions are having trouble, according to https://www.githubstatus.com