### PR TITLE
Fix image processing in xcassets.py

### DIFF
--- a/kivy_ios/tools/external/xcassets.py
+++ b/kivy_ios/tools/external/xcassets.py
@@ -673,7 +673,7 @@ def launchimage(image_xcassets, image_fn):
 
 
 def _buildimage(in_fn, out_fn, size, padcolor=None):
-    im = Image.open(in_fn)
+    im = Image.open(in_fn).convert("RGBA")
 
     # read the first left/bottom pixel
     bgcolor = im.getpixel((0, 0))
@@ -685,7 +685,7 @@ def _buildimage(in_fn, out_fn, size, padcolor=None):
         im = im.resize(newsize)
 
     # create final image
-    outim = Image.new("RGB", size, bgcolor[:3])
+    outim = Image.new("RGB", tuple(size), bgcolor[:3])
     x = (size[0] - im.size[0]) // 2
     y = (size[1] - im.size[1]) // 2
     outim.paste(im, (x, y))
@@ -703,7 +703,7 @@ def _generate(d, image_xcassets, image_fn, options, icon=False):
             filename = image_fn
 
         if icon:
-            args += [filename, "-Z", c]
+            args += [filename, "-z", c, c]
             args += [
                 "--out",
                 join(image_xcassets, d, out_fn)


### PR DESCRIPTION
So, here is a clean PR to just update the `_generate` and `_buildimage` algorithm of xcassets so images are generated correctly without any size conflicts.

Details of changes:

- Added `.convert("RGBA")` in line 676 to prevent pillow crashes while reading an image.
- Changed the sips flag from `-Z` to `-z` and passed the dimension twice (c, c) in line 706. The old `-Z` flag only constrained the maximum dimension while keeping the original aspect ratio, which often resulted in the wrong overall dimensions. The lowercase `-z` strictly forces the exact height and width required by Xcode.
- Wrapped size in tuple(size) for Image.new() in line 688.