### PR TITLE
Refactor ios_open_url for iOS 10+ compatibility

### DIFF
--- a/kivy_ios/recipes/ios/src/ios_browser.m
+++ b/kivy_ios/recipes/ios/src/ios_browser.m
@@ -9,8 +9,12 @@
 
 void ios_open_url(char *url)
 {
-	NSString *nsurl = [NSString stringWithCString:(char *)url encoding:NSUTF8StringEncoding];
-	[[UIApplication sharedApplication] openURL:[NSURL URLWithString: nsurl]];
+	NSURL *nsurl = [NSURL URLWithString: url];
+    if (@available(iOS 10.0, *)) {
+		[[UIApplication sharedApplication] openURL:nsurl options:@{} completionHandler:nil];
+    } else {
+		[[UIApplication sharedApplication] openURL:nsurl];
+    }
 }
 
 /*


### PR DESCRIPTION
Updated ios_open_url function to support iOS 10+ URL opening options.
closes #953 