### PR TITLE
:white_check_mark: Track Python test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+source = kivy_ios
+branch = True
+
+[report]
+show_missing = True
+skip_covered = False
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -37,10 +37,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-        pip install pytest
-    - name: Run pytest
+        pip install pytest pytest-cov
+    - name: Run pytest with coverage
       run: |
-        pytest tests/tools -v
+        pytest tests/tools -v --cov=kivy_ios --cov-report=term-missing --cov-report=xml
 
   build_python3_kivy:
     runs-on: ${{ matrix.runs_on }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.pyc
 *.pyo
 *.swp
+.coverage
+coverage.xml
+htmlcov/
 freetype-*
 build/*
 dist/*


### PR DESCRIPTION
Measure kivy_ios coverage in the unit-test job with pytest-cov. Keep coverage settings explicit in .coveragerc and ignore generated local coverage artifacts.
Coverage is reported but no minimum threshold is enforced and upload service integration is deferred.