### PR TITLE
fix ios_browser

### DIFF
--- a/kivy_ios/recipes/ios/src/ios_browser.m
+++ b/kivy_ios/recipes/ios/src/ios_browser.m
@@ -9,7 +9,8 @@
 
 void ios_open_url(char *url)
 {
-	NSURL *nsurl = [NSURL URLWithString: url];
+	NSString *urlString = [NSString stringWithUTF8String:url];
+	NSURL *nsurl = [NSURL URLWithString: urlString];
     if (@available(iOS 10.0, *)) {
 		[[UIApplication sharedApplication] openURL:nsurl options:@{} completionHandler:nil];
     } else {


### PR DESCRIPTION
It appears that #997 made a mistake: `url` in `ios_open_url(char *url)` is a C string. But Apple’s `+[NSURL URLWithString:]` expects an `NSString *`, not a `char *` 

This fixes this, I verfied that this fix actually works, while the current code on master does not. 